### PR TITLE
fix: combine abort signals for API requests

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -3,12 +3,15 @@ const DEFAULT_TIMEOUT = 12000;
 
 export async function getJSON(path, { signal } = {}) {
   const ctrl = new AbortController();
-  const timeout = setTimeout(()=>ctrl.abort(), DEFAULT_TIMEOUT);
+  const timeout = setTimeout(() => ctrl.abort(), DEFAULT_TIMEOUT);
+  const onAbort = () => ctrl.abort();
+  if (signal) signal.addEventListener("abort", onAbort);
   try {
-    const res = await fetch(API_BASE + path, { signal: signal || ctrl.signal });
+    const res = await fetch(API_BASE + path, { signal: ctrl.signal });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     return await res.json();
   } finally {
+    if (signal) signal.removeEventListener("abort", onAbort);
     clearTimeout(timeout);
   }
 }


### PR DESCRIPTION
## Summary
- forward external abort signal to internal controller so timeouts still apply

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b85f55ad54832ba24dec8e3b92cc2e