### PR TITLE
Load home page tables from CSV data and fix sorting

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,7 +2,9 @@ import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import StatCard from "../ui/StatCard";
 import EntityCard from "../ui/EntityCard";
+import DataTable from "../ui/DataTable";
 import { getStatewideStats, getDetectedFields } from "../lib/data";
+import { fetchCSV } from "../lib/staticData";
 import TexasMap from "../components/TexasMap";
 
 const fmtInt = (n) =>
@@ -21,13 +23,17 @@ const fmtMoney = (n) =>
 
 export default function Home() {
   const [stats, setStats] = useState(null);
+  const [indebted, setIndebted] = useState([]);
+  const [performance, setPerformance] = useState([]);
+  const [superintendents, setSuperintendents] = useState([]);
 
   useEffect(() => {
     (async () => {
       try {
+        const districtsCsv = "/data/Current_Districts_2025.csv";
         const [s, fields] = await Promise.all([
-          getStatewideStats(),
-          getDetectedFields(),
+          getStatewideStats(districtsCsv),
+          getDetectedFields(districtsCsv),
         ]);
         console.table(fields); // Inspect which headers were used
         setStats(s);
@@ -37,6 +43,106 @@ export default function Home() {
       }
     })();
   }, []);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [d, p, s] = await Promise.all([
+          fetchCSV("/data/home/indebted.csv"),
+          fetchCSV("/data/home/performance.csv"),
+          fetchCSV("/data/home/superintendents.csv"),
+        ]);
+        setIndebted(d.slice(0, 10));
+        setPerformance(p.slice(0, 10));
+        setSuperintendents(s.slice(0, 10));
+      } catch (e) {
+        console.error("Failed to load home tables:", e);
+        setIndebted([]);
+        setPerformance([]);
+        setSuperintendents([]);
+      }
+    })();
+  }, []);
+
+  const debtCols = [
+    {
+      key: "name",
+      label: "District",
+      format: (v, row) => (
+        <Link to={`/district/${row.id}`} className="text-indigo-700 hover:underline">
+          {v}
+        </Link>
+      ),
+    },
+    { key: "debt", label: "Debt", align: "right", format: (v) => fmtMoney(v) },
+    {
+      key: "perDebt",
+      label: "Per-Pupil Debt",
+      align: "right",
+      format: (v) => fmtMoney(v),
+    },
+  ];
+
+  const debtRows = indebted.map((r) => ({
+    id: r.DISTRICT_N,
+    name: r.NAME,
+    debt: Number(String(r.Debt).replace(/[\$,]/g, "")),
+    perDebt: Number(String(r["Per-Pupil Debt"]).replace(/[\$,]/g, "")),
+  }));
+
+  const perfCols = [
+    {
+      key: "name",
+      label: "District",
+      format: (v, row) => (
+        <Link to={`/district/${row.id}`} className="text-indigo-700 hover:underline">
+          {v}
+        </Link>
+      ),
+    },
+    { key: "grade", label: "Grade" },
+    { key: "score", label: "Score", align: "right" },
+  ];
+
+  const perfRows = performance.map((r) => ({
+    id: r.DISTRICT_N,
+    name: r.NAME,
+    grade: r.DISTRICT_GRADE,
+    score: Number(r.DISTRICT_SCORE),
+  }));
+
+  const supCols = [
+    {
+      key: "district",
+      label: "District",
+      format: (v, row) => (
+        <Link to={`/district/${row.id}`} className="text-indigo-700 hover:underline">
+          {v}
+        </Link>
+      ),
+    },
+    { key: "superintendent", label: "Superintendent" },
+    {
+      key: "salary",
+      label: "Salary",
+      align: "right",
+      format: (v) => fmtMoney(v),
+    },
+    {
+      key: "enrollment",
+      label: "Enrollment",
+      align: "right",
+      format: (v) => fmtInt(v),
+    },
+  ];
+
+  const supRows = superintendents.map((r) => ({
+    id: r.DISTRICT_N,
+    district: r.DISTRICT_NAME,
+    superintendent: r.SUPERINTENDENT_NAME,
+    salary: Number(String(r.FTE_SALARY).replace(/[\$,]/g, "")),
+    enrollment: Number(r.ENROLLMENT),
+  }));
 
   return (
     <div className="space-y-10">
@@ -63,6 +169,34 @@ export default function Home() {
 
       {/* 👇 Add the map back here */}
       <TexasMap />
+
+      {/* Home tables */}
+      <section className="space-y-8">
+        <div>
+          <h2 className="text-xl font-bold mb-2">Most Indebted Districts</h2>
+          <DataTable
+            columns={debtCols}
+            rows={debtRows}
+            initialSort={{ key: "debt", dir: "desc" }}
+          />
+        </div>
+        <div>
+          <h2 className="text-xl font-bold mb-2">Top Performing Districts</h2>
+          <DataTable
+            columns={perfCols}
+            rows={perfRows}
+            initialSort={{ key: "score", dir: "desc" }}
+          />
+        </div>
+        <div>
+          <h2 className="text-xl font-bold mb-2">Superintendent Salaries</h2>
+          <DataTable
+            columns={supCols}
+            rows={supRows}
+            initialSort={{ key: "salary", dir: "desc" }}
+          />
+        </div>
+      </section>
 
       {/* Recently viewed */}
       <section className="space-y-4">

--- a/src/ui/DataTable.jsx
+++ b/src/ui/DataTable.jsx
@@ -1,21 +1,39 @@
 import React from "react";
-export default function DataTable({ columns, rows, initialSort }){
-  const [sort, setSort] = React.useState(initialSort || { key: columns[0]?.key, dir: "asc" });
+export default function DataTable({ columns, rows, initialSort }) {
+  const [sort, setSort] = React.useState(
+    initialSort || { key: columns[0]?.key, dir: "asc" }
+  );
 
-  const sorted = React.useMemo(()=>{
+  const sorted = React.useMemo(() => {
     const out = [...rows];
-    out.sort((a,b)=>{
+    out.sort((a, b) => {
       const av = a[sort.key];
       const bv = b[sort.key];
-      if (av === bv) return 0;
-      const cmp = av > bv ? 1 : -1;
+
+      // Try numeric comparison first
+      const an =
+        typeof av === "number" ? av : Number(String(av).replace(/[\$,]/g, ""));
+      const bn =
+        typeof bv === "number" ? bv : Number(String(bv).replace(/[\$,]/g, ""));
+      if (!Number.isNaN(an) && !Number.isNaN(bn)) {
+        const diff = an - bn;
+        return sort.dir === "asc" ? diff : -diff;
+      }
+
+      // Fallback to string comparison
+      const as = String(av).toLowerCase();
+      const bs = String(bv).toLowerCase();
+      if (as === bs) return 0;
+      const cmp = as > bs ? 1 : -1;
       return sort.dir === "asc" ? cmp : -cmp;
     });
     return out;
   }, [rows, sort]);
 
   const toggle = (key) => {
-    setSort((s)=> s.key===key ? { key, dir: s.dir === "asc" ? "desc" : "asc" } : { key, dir: "asc" });
+    setSort((s) =>
+      s.key === key ? { key, dir: s.dir === "asc" ? "desc" : "asc" } : { key, dir: "asc" }
+    );
   };
 
   return (
@@ -24,21 +42,32 @@ export default function DataTable({ columns, rows, initialSort }){
         <table className="min-w-full text-sm">
           <thead className="bg-gray-50 border-b">
             <tr>
-              {columns.map((c)=> (
-                <th key={c.key} className={`text-left font-semibold px-4 py-3 ${c.align==='right'?'text-right':''}`}>
-                  <button onClick={()=>toggle(c.key)} className="inline-flex items-center gap-1 hover:underline">
+              {columns.map((c) => (
+                <th
+                  key={c.key}
+                  className={`text-left font-semibold px-4 py-3 ${c.align === "right" ? "text-right" : ""}`}
+                >
+                  <button
+                    onClick={() => toggle(c.key)}
+                    className="inline-flex items-center gap-1 hover:underline"
+                  >
                     {c.label}
-                    {sort.key===c.key && (<span aria-hidden>{sort.dir==='asc'?'▲':'▼'}</span>)}
+                    {sort.key === c.key && (
+                      <span aria-hidden>{sort.dir === "asc" ? "▲" : "▼"}</span>
+                    )}
                   </button>
                 </th>
               ))}
             </tr>
           </thead>
           <tbody>
-            {sorted.map((row,idx)=> (
+            {sorted.map((row, idx) => (
               <tr key={idx} className="odd:bg-white even:bg-gray-50">
-                {columns.map((c)=> (
-                  <td key={c.key} className={`px-4 py-3 ${c.align==='right'?'text-right':''}`}>
+                {columns.map((c) => (
+                  <td
+                    key={c.key}
+                    className={`px-4 py-3 ${c.align === "right" ? "text-right" : ""}`}
+                  >
                     {c.format ? c.format(row[c.key], row) : row[c.key]}
                   </td>
                 ))}


### PR DESCRIPTION
## Summary
- pull statewide metrics and home page tables directly from CSVs in `public/data`
- show top indebted districts, performance, and superintendent salaries on the home page
- make DataTable sort numeric values correctly

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9be3b235c832b8abe31d76ed93a06