### PR TITLE
Cache CSV data by URL

### DIFF
--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -58,13 +58,12 @@ function pickKey(row, candidates) {
   return null;
 }
 
-let _cache = null;
+const _cache = new Map();
 
 export async function loadDistrictsCSV(csvUrl) {
-  if (_cache) return _cache;
-
   const url = csvUrl || import.meta.env.VITE_DISTRICTS_CSV;
   if (!url) throw new Error("VITE_DISTRICTS_CSV is not set");
+  if (_cache.has(url)) return _cache.get(url);
 
   const text = await fetch(url, { cache: "force-cache" }).then((r) => {
     if (!r.ok) throw new Error(`Failed to fetch CSV: ${r.status}`);
@@ -88,8 +87,9 @@ export async function loadDistrictsCSV(csvUrl) {
   });
 
   if (!rows.length) {
-    _cache = emptyResult();
-    return _cache;
+    const empty = emptyResult();
+    _cache.set(url, empty);
+    return empty;
   }
 
   // Detect headers with a representative row
@@ -185,7 +185,7 @@ export async function loadDistrictsCSV(csvUrl) {
   // Fixed value per your spec
   const perStudentSpendingAvgFixed = 18125;
 
-  _cache = {
+  const result = {
     rows,
     byId,
     counties: Array.from(countiesSet).sort(),
@@ -207,7 +207,8 @@ export async function loadDistrictsCSV(csvUrl) {
       superintendentSalaryAvg,
     },
   };
-  return _cache;
+  _cache.set(url, result);
+  return result;
 }
 
 function emptyResult() {

--- a/src/lib/spending.js
+++ b/src/lib/spending.js
@@ -20,13 +20,12 @@ const pickKey = (row, candidates) => {
   return null;
 };
 
-let _cache = null;
+const _cache = new Map();
 
 export async function loadSpendingCSV(csvUrl) {
-  if (_cache) return _cache;
-
   const url = csvUrl || import.meta.env.VITE_SPENDING_CSV;
   if (!url) throw new Error("VITE_SPENDING_CSV is not set");
+  if (_cache.has(url)) return _cache.get(url);
 
   const text = await fetch(url, { cache: "force-cache" }).then((r) => {
     if (!r.ok) throw new Error(`Failed to fetch spending CSV: ${r.status}`);
@@ -84,8 +83,9 @@ export async function loadSpendingCSV(csvUrl) {
     new Set(normalized.map((r) => r.category).filter(Boolean))
   ).sort();
 
-  _cache = { raw: rows, records: normalized, byDistrict, categories, fields: F };
-  return _cache;
+  const result = { raw: rows, records: normalized, byDistrict, categories, fields: F };
+  _cache.set(url, result);
+  return result;
 }
 
 export async function getSpendingForDistrict(districtId) {


### PR DESCRIPTION
## Summary
- cache district CSV results per URL to prevent cross-dataset reuse
- cache spending CSV results per URL

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb9319a368832bbb7155f6ba41a5ad