### PR TITLE
Add performance grade support

### DIFF
--- a/src/lib/homeData.js
+++ b/src/lib/homeData.js
@@ -123,13 +123,25 @@ export async function loadPerformance(){
     const id   = r.DISTRICT_N ?? r.DISTRICT_ID ?? r.DISTRICT_NUMBER ?? r.ID;
     const name = r.DISTRICT_NAME ?? r.NAME ?? r.DNAME ?? "";
     const enroll = num(r.ENROLLMENT ?? r.Enrollment ?? r.ENR ?? r.STUDENTS);
-    let score = num(r.OVERALL_SCORE ?? r.SCORE ?? r.ACCOUNTABILITY_SCORE);
+    let score = num(
+      r.DISTRICT_SCORE ?? r.OVERALL_SCORE ?? r.SCORE ?? r.ACCOUNTABILITY_SCORE
+    );
+    let grade = (r.DISTRICT_GRADE ?? r.OVERALL_RATING ?? r.RATING ?? "").trim();
+
     if (!Number.isFinite(score)) {
-      const rating = String(r.OVERALL_RATING ?? r.RATING ?? "").toUpperCase();
-      score = { A:95, B:85, C:75, D:65, F:55 }[rating] ?? NaN;
+      const g = grade.toUpperCase();
+      score = { A:95, B:85, C:75, D:65, F:55 }[g] ?? NaN;
     }
-    return { id, name, score, enroll };
-  }).filter(d => d.id && d.name && Number.isFinite(d.score));
+
+    if (!grade && Number.isFinite(score)) {
+      grade = score >= 90 ? "A"
+        : score >= 80 ? "B"
+        : score >= 70 ? "C"
+        : score >= 60 ? "D" : "F";
+    }
+
+    return { id, name, score, grade, enroll };
+  }).filter(d => d.id && d.name && (Number.isFinite(d.score) || d.grade));
 
   if (debugOn()) {
     console.info("[home.performance]", {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"; 
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import StatCard from "../ui/StatCard";
 import EntityCard from "../ui/EntityCard";
@@ -21,13 +21,10 @@ const fmtMoney = (n) =>
       }).format(n)
     : "—";
 
-const scoreToGrade = (n) => {
-  if (!Number.isFinite(n)) return "—";
-  if (n >= 90) return "A";
-  if (n >= 80) return "B";
-  if (n >= 70) return "C";
-  if (n >= 60) return "D";
-  return "F";
+const displayGrade = (g) => {
+  const s = String(g ?? "").trim();
+  if (!s) return "—";
+  return s.toLowerCase() === "nr" ? "Not Rated" : s;
 };
 
 export default function Home() {
@@ -99,13 +96,18 @@ export default function Home() {
       ),
     },
     { key: "grade", label: "Grade" },
-    { key: "score", label: "Score", align: "right" },
+    {
+      key: "score",
+      label: "Score",
+      align: "right",
+      format: (v) => (Number.isFinite(v) ? v : "—"),
+    },
   ];
 
   const perfRows = performance.slice(0, 10).map((r) => ({
     id: r.id,
     name: r.name,
-    grade: scoreToGrade(r.score),
+    grade: displayGrade(r.grade),
     score: r.score,
   }));
 


### PR DESCRIPTION
## Summary
- read district scores and grades from new CSV columns with fallbacks
- surface performance grade to Home page and show "Not Rated" when applicable

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc404deb78832bb43304e603fa48a1