### PR TITLE
feat: enhance district detail KPIs

### DIFF
--- a/src/pages/CampusDetail.jsx
+++ b/src/pages/CampusDetail.jsx
@@ -25,6 +25,16 @@ const toPct = (v, digits = 1) => {
   return `${(clamped * 100).toFixed(digits)}%`;
 };
 
+const pctColor = (v) => {
+  if (!Number.isFinite(v)) return "gray";
+  const p = v > 1 ? v : v * 100;
+  if (p <= 10) return "green";
+  if (p <= 20) return "yellow";
+  if (p <= 40) return "amber";
+  if (p > 40) return "red";
+  return "gray";
+};
+
 const normKey = (s) => String(s || "").toLowerCase().replace(/[^a-z0-9]/g, "");
 
 export default function CampusDetail() {
@@ -138,17 +148,27 @@ export default function CampusDetail() {
               label="Enrollment"
               value={Number.isNaN(enrollmentNum) ? "—" : num.format(enrollmentNum)}
             />
-            <StatPill label="Reading Not On Grade-Level" value={toPct(readingNot)} />
-            <StatPill label="Math Not On Grade-Level" value={toPct(mathNot)} />
             <StatPill label="Attendance Rate" value={toPct(attendanceRate)} />
             <StatPill label="Chronic Absenteeism Rate" value={toPct(chronicAbs)} />
             <StatPill
-              label="Teacher Salary"
+              label="Average Teacher Salary"
               value={Number.isNaN(teacherSalary) ? "—" : usd.format(teacherSalary)}
             />
             <StatPill
               label="Average Admin Salary"
               value={Number.isNaN(adminSalary) ? "—" : usd.format(adminSalary)}
+            />
+            <StatPill
+              label="Not On Grade Level Reading"
+              value={Number.isFinite(readingNot) ? toPct(readingNot) : "-"}
+              color={pctColor(readingNot)}
+              boldLabel
+            />
+            <StatPill
+              label="Not On Grade Level Math"
+              value={Number.isFinite(mathNot) ? toPct(mathNot) : "-"}
+              color={pctColor(mathNot)}
+              boldLabel
             />
           </div>
         </div>

--- a/src/pages/DistrictDetail.jsx
+++ b/src/pages/DistrictDetail.jsx
@@ -453,7 +453,7 @@ export default function DistrictDetail() {
 
         <input
           className="border rounded-xl px-3 py-2 w-full md:w-96"
-          placeholder="Search campus name or ID"
+          placeholder="Don't See Your School? Search for It Here"
           value={campSearch}
           onChange={(e) => setCampSearch(e.target.value)}
         />

--- a/src/pages/DistrictDetail.jsx
+++ b/src/pages/DistrictDetail.jsx
@@ -212,8 +212,8 @@ export default function DistrictDetail() {
     if (!Number.isFinite(v)) return "gray";
     const p = v > 1 ? v : v * 100;
     if (p <= 10) return "green";
-    if (p > 10 && p <= 20) return "yellow";
-    if (p > 20 && p <= 30) return "amber";
+    if (p <= 20) return "yellow";
+    if (p <= 40) return "amber";
     if (p > 40) return "red";
     return "gray";
   };
@@ -310,6 +310,16 @@ export default function DistrictDetail() {
     return list;
   }, [campusRows, campSearch]);
 
+  const sortedCampuses = React.useMemo(
+    () => [...filteredCampuses].sort((a, b) => a.campusScore - b.campusScore),
+    [filteredCampuses]
+  );
+
+  const visibleCampuses = React.useMemo(
+    () => (campSearch ? sortedCampuses : sortedCampuses.slice(0, 15)),
+    [sortedCampuses, campSearch]
+  );
+
   const campusCols = [
     {
       key: "campusName",
@@ -392,30 +402,34 @@ export default function DistrictDetail() {
             <StatPill label="Enrollment" value={Number.isNaN(enrollment) ? "—" : num.format(enrollment)} />
             <StatPill label="Per-Pupil Spending" value={Number.isNaN(perStudent) ? "—" : usd.format(perStudent)} />
             <StatPill label="Total District Spending" value={Number.isNaN(totalSpending) ? "—" : usd.format(totalSpending)} />
-            <StatPill label="District debt" value={Number.isNaN(districtDebt) ? "—" : usd.format(districtDebt)} />
-            <StatPill label="Per‑pupil debt" value={Number.isNaN(perPupilDebt) ? "—" : usd.format(perPupilDebt)} />
+            <StatPill label="District Debt" value={Number.isNaN(districtDebt) ? "—" : usd.format(districtDebt)} />
+            <StatPill label="Per-Pupil Debt" value={Number.isNaN(perPupilDebt) ? "—" : usd.format(perPupilDebt)} />
             <StatPill label="Average Teacher Salary" value={Number.isNaN(teacherSalary) ? "—" : usd.format(teacherSalary)} />
             <StatPill label="Average Principal Salary" value={Number.isNaN(principalSal) ? "—" : usd.format(principalSal)} />
-            <StatPill label="Superintendent" value={Number.isNaN(superSalary) ? "—" : usd.format(superSalary)} />
+            <StatPill label="Superintendent Salary" value={Number.isNaN(superSalary) ? "—" : usd.format(superSalary)} />
             <StatPill
               label="Not On Grade Level Reading"
               value={Number.isFinite(readingNot) ? toPct(readingNot) : "-"}
               color={pctColor(readingNot)}
+              boldLabel
             />
             <StatPill
               label="Not On Grade Level Math"
               value={Number.isFinite(mathNot) ? toPct(mathNot) : "-"}
               color={pctColor(mathNot)}
+              boldLabel
             />
             <StatPill
-              label="Not On Grade Level SS"
+              label="Not On Grade Level Social Studies"
               value={Number.isFinite(ssNot) ? toPct(ssNot) : "-"}
               color={pctColor(ssNot)}
+              boldLabel
             />
             <StatPill
               label="Not On Grade Level Science"
               value={Number.isFinite(scienceNot) ? toPct(scienceNot) : "-"}
               color={pctColor(scienceNot)}
+              boldLabel
             />
           </div>
         </div>
@@ -446,7 +460,7 @@ export default function DistrictDetail() {
 
         <DataTable
           columns={campusCols}
-          rows={filteredCampuses}
+          rows={visibleCampuses}
           initialSort={{ key: "campusScore", dir: "asc" }}
         />
       </section>

--- a/src/pages/DistrictDetail.jsx
+++ b/src/pages/DistrictDetail.jsx
@@ -162,6 +162,43 @@ export default function DistrictDetail() {
   const principalSal = k("Average Principal Salary", "PRINCIPAL_SALARY");
   const superSalary = k("Superintendent Salary", "SUPERINTENDENT_SALARY");
 
+  const readingNot = toNum(
+    pickHdr(
+      row,
+      hdr,
+      "Not On Grade Level Reading",
+      "Reading Not On Grade Level",
+      "Reading Not on Grade-Level"
+    )
+  );
+  const mathNot = toNum(
+    pickHdr(
+      row,
+      hdr,
+      "Not On Grade Level Math",
+      "Math Not On Grade Level",
+      "Math Not on Grade-Level"
+    )
+  );
+  const ssNot = toNum(
+    pickHdr(
+      row,
+      hdr,
+      "Not On Grade Level SS",
+      "Not On Grade Level Social Studies",
+      "Social Studies Not On Grade Level"
+    )
+  );
+  const scienceNot = toNum(
+    pickHdr(
+      row,
+      hdr,
+      "Not On Grade Level Science",
+      "Science Not On Grade Level",
+      "Science Not on Grade-Level"
+    )
+  );
+
   const districtGrade = pickHdr(row, hdr, "District Grade", "DISTRICT_GRADE", "Grade");
   const districtScore = k("District Score", "DISTRICT_SCORE", "Score");
 
@@ -170,6 +207,16 @@ export default function DistrictDetail() {
     : !Number.isNaN(totalSpending) && !Number.isNaN(enrollment) && enrollment > 0
     ? totalSpending / enrollment
     : NaN;
+
+  const pctColor = (v) => {
+    if (!Number.isFinite(v)) return "gray";
+    const p = v > 1 ? v : v * 100;
+    if (p <= 10) return "green";
+    if (p > 10 && p <= 20) return "yellow";
+    if (p > 20 && p <= 30) return "amber";
+    if (p > 40) return "red";
+    return "gray";
+  };
 
   // campuses table rows
   const campusRows = React.useMemo(
@@ -335,7 +382,7 @@ export default function DistrictDetail() {
             <p className="text-gray-600 mt-1">{county}</p>
             {(districtGrade || Number.isFinite(districtScore)) && (
               <div className="mt-3 flex items-center gap-2">
-                <span className="font-bold">District Grade</span>
+                <span className="font-bold">TEA's District Grade</span>
                 <GradeScorePill grade={districtGrade} score={districtScore} />
               </div>
             )}
@@ -343,19 +390,39 @@ export default function DistrictDetail() {
 
           <div className="flex flex-wrap gap-2">
             <StatPill label="Enrollment" value={Number.isNaN(enrollment) ? "—" : num.format(enrollment)} />
-            <StatPill label="Per pupil" value={Number.isNaN(perStudent) ? "—" : usd.format(perStudent)} />
-            <StatPill label="Total spend" value={Number.isNaN(totalSpending) ? "—" : usd.format(totalSpending)} />
+            <StatPill label="Per-Pupil Spending" value={Number.isNaN(perStudent) ? "—" : usd.format(perStudent)} />
+            <StatPill label="Total District Spending" value={Number.isNaN(totalSpending) ? "—" : usd.format(totalSpending)} />
             <StatPill label="District debt" value={Number.isNaN(districtDebt) ? "—" : usd.format(districtDebt)} />
             <StatPill label="Per‑pupil debt" value={Number.isNaN(perPupilDebt) ? "—" : usd.format(perPupilDebt)} />
-            <StatPill label="Teacher salary" value={Number.isNaN(teacherSalary) ? "—" : usd.format(teacherSalary)} />
-            <StatPill label="Principal salary" value={Number.isNaN(principalSal) ? "—" : usd.format(principalSal)} />
+            <StatPill label="Average Teacher Salary" value={Number.isNaN(teacherSalary) ? "—" : usd.format(teacherSalary)} />
+            <StatPill label="Average Principal Salary" value={Number.isNaN(principalSal) ? "—" : usd.format(principalSal)} />
             <StatPill label="Superintendent" value={Number.isNaN(superSalary) ? "—" : usd.format(superSalary)} />
+            <StatPill
+              label="Not On Grade Level Reading"
+              value={Number.isFinite(readingNot) ? toPct(readingNot) : "-"}
+              color={pctColor(readingNot)}
+            />
+            <StatPill
+              label="Not On Grade Level Math"
+              value={Number.isFinite(mathNot) ? toPct(mathNot) : "-"}
+              color={pctColor(mathNot)}
+            />
+            <StatPill
+              label="Not On Grade Level SS"
+              value={Number.isFinite(ssNot) ? toPct(ssNot) : "-"}
+              color={pctColor(ssNot)}
+            />
+            <StatPill
+              label="Not On Grade Level Science"
+              value={Number.isFinite(scienceNot) ? toPct(scienceNot) : "-"}
+              color={pctColor(scienceNot)}
+            />
           </div>
         </div>
       </header>
 
       <section className="bg-white border rounded-2xl p-6 space-y-3">
-        <h2 className="text-xl font-bold">Geometry</h2>
+        <h2 className="text-xl font-bold">District Boundary</h2>
         {geom ? <LeafMap geom={geom} height={420} /> : <p className="text-gray-600">No geometry found.</p>}
       </section>
 

--- a/src/ui/StatPill.jsx
+++ b/src/ui/StatPill.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function StatPill({ label, value, color = "gray" }) {
+export default function StatPill({ label, value, color = "gray", boldLabel = false }) {
   const styles = {
     gray: "bg-gray-50",
     green: "bg-green-100 text-green-800",
@@ -9,10 +9,11 @@ export default function StatPill({ label, value, color = "gray" }) {
     red: "bg-red-100 text-red-800",
   };
   const cls = styles[color] || styles.gray;
+  const labelCls = boldLabel ? "text-gray-600 font-bold" : "text-gray-600";
 
   return (
     <div className={`rounded-xl border px-3 py-2 text-sm ${cls}`}>
-      <p className="text-gray-600">{label}</p>
+      <p className={labelCls}>{label}</p>
       <p className="font-bold">{value}</p>
     </div>
   );

--- a/src/ui/StatPill.jsx
+++ b/src/ui/StatPill.jsx
@@ -1,7 +1,17 @@
 import React from "react";
-export default function StatPill({ label, value }){
+
+export default function StatPill({ label, value, color = "gray" }) {
+  const styles = {
+    gray: "bg-gray-50",
+    green: "bg-green-100 text-green-800",
+    yellow: "bg-yellow-100 text-yellow-800",
+    amber: "bg-amber-100 text-amber-800",
+    red: "bg-red-100 text-red-800",
+  };
+  const cls = styles[color] || styles.gray;
+
   return (
-    <div className="rounded-xl border px-3 py-2 text-sm bg-gray-50">
+    <div className={`rounded-xl border px-3 py-2 text-sm ${cls}`}>
       <p className="text-gray-600">{label}</p>
       <p className="font-bold">{value}</p>
     </div>


### PR DESCRIPTION
## Summary
- rename district grade and spending KPI labels
- add color-coded performance pills for reading, math, social studies, and science
- retitle geometry section to "District Boundary"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1c89dd828832ba94d47494cd1d118