### PR TITLE
Add Solutions page with policy prescriptions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import CampusDetail from "./pages/CampusDetail";
 import Search from "./pages/Search";
 import NotFound from "./pages/NotFound";
 import About from "./pages/About";
+import Solutions from "./pages/Solutions";
 import ErrorBoundary from "./shell/ErrorBoundary";
 
 // Lazy-load the money explainer page so it doesn't evaluate unless visited
@@ -28,10 +29,11 @@ export default function App() {
               <Route path="/campuses" element={<Campuses />} />
               <Route path="/campus/:id" element={<CampusDetail />} />
               <Route path="/search" element={<Search />} />
-                <Route
-                  path="/why-no-amount-of-money-is-enough"
-                  element={<WhyNoAmount />}
-                />
+              <Route
+                path="/why-no-amount-of-money-is-enough"
+                element={<WhyNoAmount />}
+              />
+              <Route path="/solutions" element={<Solutions />} />
               <Route path="/about" element={<About />} />
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/pages/Solutions.jsx
+++ b/src/pages/Solutions.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+export default function Solutions() {
+  const items = [
+    {
+      title: "Audit School Contracts",
+      description:
+        "Require districts to publish all vendor contracts and spending details in a searchable database. Transparency discourages waste and allows taxpayers to see where funds are going.",
+    },
+    {
+      title: "Prioritize Classroom Funding",
+      description:
+        "Cap administrative overhead and direct the majority of new revenue to teacher pay, instructional materials, and student services.",
+    },
+    {
+      title: "Empower Local Decision-Making",
+      description:
+        "Give campuses flexibility to adopt cost-effective tools and programs while holding them accountable for results.",
+    },
+  ];
+
+  return (
+    <div className="bg-white border rounded-2xl p-6 space-y-4 max-w-3xl">
+      <h1 className="text-2xl font-bold">Solutions</h1>
+      <ul className="space-y-6 list-disc pl-6">
+        {items.map(({ title, description }) => (
+          <li key={title}>
+            <p className="font-semibold">{title}</p>
+            <p className="text-gray-700">{description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/shell/Layout.jsx
+++ b/src/shell/Layout.jsx
@@ -31,6 +31,14 @@ function TopBar() {
             >
               Why No Amount of Money is Enough
             </NavLink>
+            <NavLink
+              to="/solutions"
+              className={({ isActive }) =>
+                `hover:text-blue-700 ${isActive ? 'text-blue-700' : 'text-gray-600'}`
+              }
+            >
+              Solutions
+            </NavLink>
           <NavLink to="/about" className={({isActive})=>`hover:text-blue-700 ${isActive?'text-blue-700':'text-gray-600'}`}>About</NavLink>
         </nav>
         <div className="ml-auto w-full md:w-96">


### PR DESCRIPTION
## Summary
- add "Solutions" page listing policy proposals with descriptive text
- expose Solutions at `/solutions` route and navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c772c1e7a4832ba0831d50244b4e5f