### PR TITLE
feat: improve spending chart readability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-leaflet": "^4.2.1",
-        "react-router-dom": "^6.26.1"
+        "react-router-dom": "^6.26.1",
+        "recharts": "^3.2.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.1",
@@ -840,6 +841,32 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1136,6 +1163,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1181,11 +1220,80 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1446,6 +1554,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1511,6 +1628,127 @@
         "node": ">=4"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1528,6 +1766,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -1563,6 +1807,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.10",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1612,6 +1866,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1777,6 +2037,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -2389,6 +2668,13 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-leaflet": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
@@ -2401,6 +2687,29 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -2467,6 +2776,54 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+      "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -2830,6 +3187,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2881,12 +3244,43 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.19",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-leaflet": "^4.2.1",
-    "react-router-dom": "^6.26.1"
+    "react-router-dom": "^6.26.1",
+    "recharts": "^3.2.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import DistrictDetail from "./pages/DistrictDetail";
 import Campuses from "./pages/Campuses";
 import CampusDetail from "./pages/CampusDetail";
 import Search from "./pages/Search";
+import LongitudinalSpending from "./pages/LongitudinalSpending";
 import NotFound from "./pages/NotFound";
 import About from "./pages/About";
 import Solutions from "./pages/Solutions";
@@ -29,6 +30,7 @@ export default function App() {
               <Route path="/campuses" element={<Campuses />} />
               <Route path="/campus/:id" element={<CampusDetail />} />
               <Route path="/search" element={<Search />} />
+              <Route path="/spending" element={<LongitudinalSpending />} />
               <Route
                 path="/why-no-amount-of-money-is-enough"
                 element={<WhyNoAmount />}

--- a/src/pages/LongitudinalSpending.jsx
+++ b/src/pages/LongitudinalSpending.jsx
@@ -1,0 +1,568 @@
+// src/pages/LongitudinalSpending.jsx
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  LineChart, Line, XAxis, YAxis, Tooltip, Legend,
+  ResponsiveContainer, BarChart, Bar, CartesianGrid
+} from "recharts";
+
+// Absolute URLs to CSV files served from public/
+const TOTALS_CSV = "/data/Spending_Longitudinal_Totals.csv";
+const BY_OBJECT_CSV = "/data/Spending_By_Object_Long.csv";
+
+// Small CSV parser that supports quoted fields and embedded commas
+function parseCSV(text, delimiter = ",") {
+  const rows = [];
+  let i = 0, field = "", row = [], inQuotes = false;
+
+  function pushField() { row.push(field); field = ""; }
+  function pushRow() { if (row.length) rows.push(row); row = []; }
+
+  for (; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        const next = text[i + 1];
+        if (next === '"') { field += '"'; i++; } else { inQuotes = false; }
+      } else {
+        field += c;
+      }
+    } else {
+      if (c === '"') {
+        inQuotes = true;
+      } else if (c === delimiter) {
+        pushField();
+      } else if (c === "\n") {
+        pushField(); pushRow();
+      } else if (c === "\r") {
+        // swallow CR and handle CRLF
+      } else {
+        field += c;
+      }
+    }
+  }
+  // flush last field and row
+  pushField(); pushRow();
+
+  // remove empty trailing rows
+  while (rows.length && rows[rows.length - 1].every(v => v === "")) rows.pop();
+
+  if (!rows.length) return [];
+
+  // dedupe headers if duplicated
+  const header = rows[0];
+  const nameMap = {};
+  const headers = header.map(h => {
+    const key = h || "col";
+    nameMap[key] = (nameMap[key] || 0) + 1;
+    return nameMap[key] === 1 ? key : `${key}_${nameMap[key]}`;
+  });
+
+  const out = [];
+  for (let r = 1; r < rows.length; r++) {
+    const obj = {};
+    const arr = rows[r];
+    for (let c = 0; c < headers.length; c++) {
+      obj[headers[c]] = arr[c] ?? "";
+    }
+    out.push(obj);
+  }
+  return out;
+}
+
+// coerce numbers like "$3,182,288.00" to 3182288
+const toNumber = (v) => {
+  if (v == null) return 0;
+  if (typeof v === "number") return v;
+  const n = parseFloat(String(v).replace(/\$/g, "").replace(/,/g, "").trim());
+  return Number.isFinite(n) ? n : 0;
+};
+
+// compact friendly money format for axes and tooltips
+const fmtShortUSD = (n) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(n || 0);
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+    const mql = window.matchMedia("(max-width: 640px)");
+    const onChange = () => setIsMobile(mql.matches);
+    onChange();
+    mql.addEventListener?.("change", onChange);
+    return () => mql.removeEventListener?.("change", onChange);
+  }, []);
+  return isMobile;
+}
+
+// local loader with error logging
+async function loadCsv(url) {
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) {
+    console.error("CSV fetch failed", url, res.status);
+    return [];
+  }
+  const text = await res.text();
+  const rows = parseCSV(text);
+  return rows;
+}
+
+const COLORS = {
+  total: "#0B3D91",
+  consultant: "#1F66D1",
+  teacher: "#FFC72C",
+  professional: "#4D8FEA",
+  legal: "#FF8C00",
+  lobbying: "#B8552F",
+  other: "#7FB1F2",
+};
+
+const BAR_COLORS = [
+  COLORS.consultant,
+  COLORS.professional,
+  COLORS.teacher,
+  COLORS.legal,
+  COLORS.lobbying,
+  COLORS.other,
+];
+
+const TEACHER_PAY_LABEL = "Teacher Pay";
+
+const OBJECT_LABEL_OVERRIDES = {
+  "BUILDING PURCHASE, CONSTRUCTION OR IMPROVEMENTS": "Building Purchases",
+  "CONSULTING SERVICES": "Consultants",
+  "PROFESSIONAL SERVICES": "Professional Services",
+  "MISCELLANEOUS CONTRACTED SERVICES": "Miscellaneous Contracts",
+  "TEACHER PAY & OTHER PROFESSIONALS": TEACHER_PAY_LABEL,
+  "LEGAL SERVICES": "Legal Services",
+  "LOBBYING": "Lobbying",
+};
+
+const DEFAULT_OBJECTS = [
+  "Consultants",
+  "Professional Services",
+  "Miscellaneous Contracts",
+  "Legal Services",
+  "Lobbying",
+];
+
+const SMALL_WORDS = new Set(["and", "or", "the", "for", "of", "to", "a", "an", "in", "on", "by"]);
+const ACRONYM_WORDS = new Set([
+  "ADA",
+  "ACT",
+  "CTE",
+  "ELL",
+  "ESL",
+  "FICA",
+  "FTE",
+  "GT",
+  "IDEA",
+  "IRS",
+  "PEIMS",
+  "SAT",
+  "SSA",
+  "TEA",
+  "TRS",
+  "TSI",
+]);
+
+function toTitleCase(value) {
+  if (!value) return "";
+  const parts = String(value).split(/([\s\/\-&,]+)/);
+  return parts
+    .map((part, index) => {
+      if (/^[\s\/\-&,]+$/.test(part)) return part;
+      const lower = part.toLowerCase();
+      if (SMALL_WORDS.has(lower) && index !== 0 && index !== parts.length - 1) {
+        return lower;
+      }
+      if (ACRONYM_WORDS.has(part.toUpperCase())) {
+        return part.toUpperCase();
+      }
+      if (/^[0-9]+$/.test(lower)) {
+        return part;
+      }
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join("")
+    .replace(/\bId\b/g, "ID");
+}
+
+function getObjectLabel(raw) {
+  const base = String(raw || "").trim();
+  if (!base) return "";
+  const override = OBJECT_LABEL_OVERRIDES[base.toUpperCase()];
+  return override || toTitleCase(base);
+}
+
+export default function LongitudinalSpending() {
+  const [totals, setTotals] = useState([]);     // rows with DISTRICT_N, District_Name, Year, Total_Spending
+  const [objects, setObjects] = useState([]);   // rows with DISTRICT_N, District_Name, Year, Object_Description_Long, Object_Spending
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState(["STATEWIDE"]); // default statewide chip
+  const [selectedObjects, setSelectedObjects] = useState(DEFAULT_OBJECTS);
+  const [objectSelectValue, setObjectSelectValue] = useState("");
+
+  const isMobile = useIsMobile();
+  const CHART_H_LINE = isMobile ? 280 : 360;
+  const CHART_H_BAR = isMobile ? 320 : 420;
+  const AXIS_FONT = { fontSize: isMobile ? 12 : 13 };
+  const LINE_STROKE = isMobile ? 3.5 : 3.75;
+  const DOT_R = isMobile ? 3.5 : 4.5;
+  const ACTIVE_DOT_R = isMobile ? 6.5 : 7.5;
+
+  useEffect(() => {
+    let cancelled = false;
+    async function go() {
+      try {
+        setLoading(true);
+        const [tRows, oRows] = await Promise.all([loadCsv(TOTALS_CSV), loadCsv(BY_OBJECT_CSV)]);
+
+        // normalize column names exactly as expected
+        const t = tRows.map(r => ({
+          DISTRICT_N: r.DISTRICT_N ?? r.DISTRICT ?? r.District_ID ?? "",
+          District_Name: r.District_Name ?? r.DISTNAME ?? r.District ?? "",
+          Year: Number(r.Year),
+          Total_Spending: toNumber(r.Total_Spending ?? r.Total ?? r.Amount ?? r.SumOfACTAMT)
+        })).filter(r => r.Year && r.DISTRICT_N);
+
+        const o = oRows.map(r => ({
+          DISTRICT_N: r.DISTRICT_N ?? r.DISTRICT ?? r.District_ID ?? "",
+          District_Name: r.District_Name ?? r.DISTNAME ?? r.District ?? "",
+          Year: Number(r.Year),
+          Object_Code: r.Object_Code ?? r.OBJECT ?? "",
+          Object_Description_Long: r.Object_Description_Long ?? r.OBJECTX_LONG ?? r.Object_Long ?? "",
+          Object_Spending: toNumber(r.Object_Spending ?? r.Amount ?? r.SumOfACTAMT)
+        })).filter(r => r.Year && r.DISTRICT_N && r.Object_Description_Long);
+
+        if (!cancelled) {
+          setTotals(t);
+          setObjects(o);
+          setError("");
+        }
+      } catch (e) {
+        console.error("Data load error", e);
+        if (!cancelled) setError("Could not load spending data");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    go();
+    return () => { cancelled = true; };
+  }, []);
+
+  const districts = useMemo(() => {
+    const map = new Map();
+    totals.forEach(r => { if (!map.has(r.DISTRICT_N)) map.set(r.DISTRICT_N, r.District_Name); });
+    if (map.size === 0) {
+      objects.forEach(r => { if (!map.has(r.DISTRICT_N)) map.set(r.DISTRICT_N, r.District_Name); });
+    }
+    return Array.from(map, ([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name));
+  }, [totals, objects]);
+
+  const addDistrict = (id) => { if (!selected.includes(id)) setSelected(prev => [...prev, id]); setQuery(""); };
+  const removeDistrict = (id) => setSelected(prev => prev.filter(x => x !== id));
+
+  const filteredOptions = useMemo(() => {
+    const q = query.toLowerCase();
+    return districts.filter(d => d.name.toLowerCase().includes(q) || d.id.includes(query)).slice(0, 10);
+  }, [districts, query]);
+
+  const totalsByYear = useMemo(() => {
+    const map = new Map();
+    totals.forEach(r => {
+      if (!selected.includes(r.DISTRICT_N)) return;
+      const y = Number(r.Year);
+      if (!y) return;
+      map.set(y, (map.get(y) || 0) + toNumber(r.Total_Spending));
+    });
+    return map;
+  }, [totals, selected]);
+
+  const objectsByYear = useMemo(() => {
+    const map = new Map();
+    objects.forEach(r => {
+      if (!selected.includes(r.DISTRICT_N)) return;
+      const y = Number(r.Year);
+      if (!y) return;
+      const name = getObjectLabel(r.Object_Description_Long ?? r.Object_Long ?? r.OBJECTX_LONG ?? "");
+      if (!name) return;
+      const totalsForYear = map.get(y) || {};
+      totalsForYear[name] = (totalsForYear[name] || 0) + toNumber(r.Object_Spending);
+      map.set(y, totalsForYear);
+    });
+    return map;
+  }, [objects, selected]);
+
+  const totalYears = useMemo(() => Array.from(totalsByYear.keys()).sort((a, b) => a - b), [totalsByYear]);
+  const objectYears = useMemo(() => Array.from(objectsByYear.keys()).sort((a, b) => a - b), [objectsByYear]);
+  const years = useMemo(() => {
+    const set = new Set([...totalYears, ...objectYears]);
+    return Array.from(set).sort((a, b) => a - b);
+  }, [totalYears, objectYears]);
+
+  // Overall spending series across selected districts
+  const overallSeries = useMemo(() => {
+    if (!years.length) return [];
+    return years.map(year => {
+      const totalsForYear = objectsByYear.get(year) || {};
+      const total = totalsByYear.get(year) || 0;
+      const teacherPay = totalsForYear[TEACHER_PAY_LABEL] || 0;
+      return {
+        Year: year,
+        Total: total,
+        [TEACHER_PAY_LABEL]: teacherPay,
+      };
+    });
+  }, [years, totalsByYear, objectsByYear]);
+
+  // Cost centers by object long across selected districts
+  const costCenterSeries = useMemo(() => {
+    if (!selectedObjects.length) return [];
+    return objectYears.map(year => {
+      const totalsForYear = objectsByYear.get(year) || {};
+      const row = { Year: year };
+      selectedObjects.forEach(name => {
+        row[name] = totalsForYear[name] || 0;
+      });
+      return row;
+    });
+  }, [objectYears, objectsByYear, selectedObjects]);
+
+  const objectOptions = useMemo(() => {
+    const opts = new Set();
+    objects.forEach(r => {
+      const name = getObjectLabel(r.Object_Description_Long ?? r.Object_Long ?? r.OBJECTX_LONG ?? "");
+      if (name) opts.add(name);
+    });
+    return Array.from(opts).sort((a, b) => a.localeCompare(b));
+  }, [objects]);
+
+  useEffect(() => {
+    if (!objectOptions.length) return;
+    setSelectedObjects(prev => {
+      const filtered = prev.filter(name => objectOptions.includes(name));
+      let next = filtered;
+      if (filtered.length === 0) {
+        const fallback = DEFAULT_OBJECTS.filter(name => objectOptions.includes(name));
+        if (fallback.length) {
+          next = fallback;
+        } else {
+          next = objectOptions.slice(0, Math.min(5, objectOptions.length));
+        }
+      }
+      if (next.length === prev.length && next.every((name, idx) => name === prev[idx])) {
+        return prev;
+      }
+      return next;
+    });
+  }, [objectOptions]);
+
+  const addObject = (name) => {
+    if (!name) return;
+    setSelectedObjects(prev => (prev.includes(name) ? prev : [...prev, name]));
+  };
+
+  const removeObject = (name) => {
+    setSelectedObjects(prev => prev.filter(item => item !== name));
+  };
+
+  const handleObjectSelect = (event) => {
+    const { value } = event.target;
+    if (!value) return;
+    addObject(value);
+    setObjectSelectValue("");
+  };
+
+  return (
+    <main className="px-4 md:px-8 space-y-8">
+      <h1 className="text-3xl font-extrabold">Spending over time</h1>
+
+      {/* search and selected chips */}
+      <div className="space-y-3">
+        <input
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder="Search district by name or ID"
+          className="w-full max-w-xl border rounded px-3 py-2"
+        />
+        {query && (
+          <div className="border rounded p-2 max-w-xl bg-white">
+            {filteredOptions.map(o => (
+              <div key={o.id} className="cursor-pointer py-1 px-2 hover:bg-gray-100" onClick={() => addDistrict(o.id)}>
+                {o.name} ({o.id})
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="flex flex-wrap gap-2">
+          {selected.map(id => {
+            const name = districts.find(d => d.id === id)?.name || id;
+            return (
+              <button key={id} onClick={() => removeDistrict(id)} className="px-2 py-1 rounded bg-blue-100">
+                {name}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {loading && <div className="text-sm text-gray-500">Loading spending data</div>}
+      {error && <div className="text-sm text-red-600">{error}</div>}
+
+      {/* Overall spending */}
+      <section>
+        <h2 className="text-xl font-bold mb-2">Overall spending</h2>
+        <ResponsiveContainer width="100%" height={CHART_H_LINE}>
+          <LineChart
+            data={overallSeries}
+            margin={{ top: 8, right: isMobile ? 8 : 16, bottom: 12, left: 8 }}
+          >
+            <CartesianGrid strokeOpacity={0.25} strokeDasharray="3 3" />
+            <XAxis
+              dataKey="Year"
+              tick={AXIS_FONT}
+              tickMargin={8}
+              minTickGap={isMobile ? 6 : 12}
+              axisLine={false}
+            />
+            <YAxis
+              tick={AXIS_FONT}
+              tickFormatter={fmtShortUSD}
+              width={isMobile ? 58 : 70}
+              axisLine={false}
+              domain={[0, "dataMax"]}
+            />
+            <Tooltip
+              formatter={(v) => fmtShortUSD(v)}
+              labelFormatter={(y) => `Year ${y}`}
+              contentStyle={{ fontSize: isMobile ? 12 : 13 }}
+            />
+            <Legend
+              verticalAlign="top"
+              align="left"
+              iconType="circle"
+              wrapperStyle={{ paddingBottom: 6, fontSize: isMobile ? 12 : 13 }}
+            />
+            <Line
+              type="monotone"
+              dataKey="Total"
+              name="Total"
+              stroke={COLORS.total}
+              strokeWidth={LINE_STROKE}
+              strokeLinecap="round"
+              dot={{ r: DOT_R }}
+              activeDot={{ r: ACTIVE_DOT_R, strokeWidth: 2 }}
+              connectNulls
+            />
+            <Line
+              type="monotone"
+              dataKey={TEACHER_PAY_LABEL}
+              name={TEACHER_PAY_LABEL}
+              stroke={COLORS.teacher}
+              strokeWidth={LINE_STROKE}
+              strokeLinecap="round"
+              dot={{ r: DOT_R }}
+              activeDot={{ r: ACTIVE_DOT_R, strokeWidth: 2 }}
+              connectNulls
+            />
+          </LineChart>
+        </ResponsiveContainer>
+        {!loading && overallSeries.length === 0 && (
+          <div className="text-sm text-gray-500 mt-2">No data available for current selection</div>
+        )}
+      </section>
+
+      {/* Cost centers by object */}
+      <section>
+        <h2 className="text-xl font-bold mb-2">Cost centers by object</h2>
+        <div className="space-y-2 mb-4">
+          <label htmlFor="object-filter" className="block text-sm font-medium text-gray-700">
+            Add or remove cost centers
+          </label>
+          <select
+            id="object-filter"
+            value={objectSelectValue}
+            onChange={handleObjectSelect}
+            disabled={!objectOptions.length}
+            className="w-full max-w-sm border rounded px-3 py-2 bg-white"
+          >
+            <option value="" disabled>
+              {objectOptions.length ? "Select cost center" : "Loading cost centers"}
+            </option>
+            {objectOptions.map(name => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+          <div className="flex flex-wrap gap-2">
+            {selectedObjects.map(name => (
+              <button
+                key={name}
+                type="button"
+                onClick={() => removeObject(name)}
+                className="px-2 py-1 rounded bg-blue-100"
+              >
+                {name}
+              </button>
+            ))}
+          </div>
+        </div>
+        <ResponsiveContainer width="100%" height={CHART_H_BAR}>
+          <BarChart
+            data={costCenterSeries}
+            margin={{ top: 8, right: isMobile ? 8 : 16, bottom: 12, left: 8 }}
+            barCategoryGap={isMobile ? "28%" : "24%"}
+            barGap={isMobile ? 2 : 4}
+            maxBarSize={isMobile ? 28 : 36}
+          >
+            <CartesianGrid strokeOpacity={0.25} strokeDasharray="3 3" />
+            <XAxis
+              dataKey="Year"
+              tick={AXIS_FONT}
+              tickMargin={8}
+              minTickGap={isMobile ? 6 : 12}
+              axisLine={false}
+            />
+            <YAxis
+              tick={AXIS_FONT}
+              tickFormatter={fmtShortUSD}
+              width={isMobile ? 58 : 70}
+              axisLine={false}
+              domain={[0, "dataMax"]}
+            />
+            <Tooltip
+              formatter={(v, n) => [fmtShortUSD(v), n]}
+              labelFormatter={(y) => `Year ${y}`}
+              contentStyle={{ fontSize: isMobile ? 12 : 13 }}
+            />
+            <Legend
+              verticalAlign="top"
+              align="left"
+              iconType="circle"
+              wrapperStyle={{ paddingBottom: 6, fontSize: isMobile ? 12 : 13 }}
+            />
+            {selectedObjects.map((k, i) => {
+              const fills = BAR_COLORS;
+              return <Bar key={k} dataKey={k} name={k} fill={fills[i % fills.length]} />;
+            })}
+          </BarChart>
+        </ResponsiveContainer>
+        {!loading && (selectedObjects.length === 0 || costCenterSeries.length === 0) && (
+          <div className="text-sm text-gray-500 mt-2">
+            {selectedObjects.length === 0
+              ? "Select at least one cost center to display spending trends"
+              : "No data available for current selection"}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/shell/Layout.jsx
+++ b/src/shell/Layout.jsx
@@ -1,6 +1,15 @@
 import React from "react";
 import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 
+const NAV_LINKS = [
+  { to: "/districts", label: "Districts" },
+  { to: "/campuses", label: "Campuses" },
+  { to: "/spending", label: "Trends in Spending" },
+  { to: "/why-no-amount-of-money-is-enough", label: "Why No Amount of Money is Enough" },
+  { to: "/solutions", label: "Solutions" },
+  { to: "/about", label: "About" },
+];
+
 export default function Layout({ children }) {
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900">
@@ -14,37 +23,74 @@ export default function Layout({ children }) {
 }
 
 function TopBar() {
+  const [menuOpen, setMenuOpen] = React.useState(false);
+
+  const toggleMenu = () => {
+    setMenuOpen((open) => !open);
+  };
+
+  const closeMenu = () => setMenuOpen(false);
+
   return (
     <header className="sticky top-0 z-40 bg-white/90 backdrop-blur border-b">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center gap-4">
         <Link to="/" className="font-black tracking-tight text-xl">
           LoneStar Ledger
         </Link>
+        <button
+          type="button"
+          onClick={toggleMenu}
+          className="md:hidden inline-flex items-center justify-center rounded-lg p-2 text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-600"
+          aria-label="Toggle navigation menu"
+          aria-expanded={menuOpen}
+        >
+          {menuOpen ? (
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-6 h-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 6l12 12M18 6l-12 12" />
+            </svg>
+          ) : (
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-6 h-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M4 12h16M4 17h16" />
+            </svg>
+          )}
+        </button>
         <nav className="hidden md:flex items-center gap-6 text-sm">
-          <NavLink to="/districts" className={({isActive})=>`hover:text-blue-700 ${isActive?'text-blue-700':'text-gray-600'}`}>Districts</NavLink>
-          <NavLink to="/campuses" className={({isActive})=>`hover:text-blue-700 ${isActive?'text-blue-700':'text-gray-600'}`}>Campuses</NavLink>
+          {NAV_LINKS.map(({ to, label }) => (
             <NavLink
-              to="/why-no-amount-of-money-is-enough"
+              key={to}
+              to={to}
               className={({ isActive }) =>
-                `hover:text-blue-700 ${isActive ? 'text-blue-700' : 'text-gray-600'}`
+                `hover:text-blue-700 ${isActive ? "text-blue-700" : "text-gray-600"}`
               }
             >
-              Why No Amount of Money is Enough
+              {label}
             </NavLink>
-            <NavLink
-              to="/solutions"
-              className={({ isActive }) =>
-                `hover:text-blue-700 ${isActive ? 'text-blue-700' : 'text-gray-600'}`
-              }
-            >
-              Solutions
-            </NavLink>
-          <NavLink to="/about" className={({isActive})=>`hover:text-blue-700 ${isActive?'text-blue-700':'text-gray-600'}`}>About</NavLink>
+          ))}
         </nav>
-        <div className="ml-auto w-full md:w-96">
+        <div className="ml-auto flex-1 min-w-0 md:flex-none md:w-96">
           <GlobalSearch />
         </div>
       </div>
+      {menuOpen && (
+        <div className="md:hidden border-t border-gray-200 bg-white">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col gap-1.5">
+            {NAV_LINKS.map(({ to, label }) => (
+              <NavLink
+                key={to}
+                to={to}
+                onClick={closeMenu}
+                className={({ isActive }) =>
+                  `block rounded-lg px-2 py-2 text-base font-medium hover:bg-gray-50 ${
+                    isActive ? "text-blue-700" : "text-gray-700"
+                  }`
+                }
+              >
+                {label}
+              </NavLink>
+            ))}
+          </div>
+        </div>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add compact USD formatter and mobile detection helpers so the spending charts adapt sizing and typography across screen widths
- restyle the overall spending line chart with thicker strokes, yearly dots, compact axes, and a top-aligned legend for better clarity
- tighten the cost center bar chart spacing, legend placement, and tooltips while using compact currency ticks for easier reading on phones

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2d9603468832b9a37a1770ccaeb61