### PR TITLE
Ensure stat pills wrap safely and darken detail titles

### DIFF
--- a/src/pages/CampusDetail.jsx
+++ b/src/pages/CampusDetail.jsx
@@ -136,7 +136,7 @@ export default function CampusDetail() {
             <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">{name}</h1>
             {(campusGrade || Number.isFinite(campusScore)) && (
               <div className="mt-3 flex items-center gap-2">
-                <span className="font-bold">Campus Grade</span>
+                <span className="font-bold text-gray-900">Campus Grade</span>
                 <GradeScorePill grade={campusGrade} score={campusScore} />
               </div>
             )}
@@ -175,7 +175,7 @@ export default function CampusDetail() {
       </header>
 
       <section className="bg-white border rounded-2xl p-6 space-y-3">
-        <h2 className="text-xl font-bold">Campus Location</h2>
+        <h2 className="text-xl font-bold text-gray-900">Campus Location</h2>
         {geom ? (
           <LeafMap geom={geom} height={420} />
         ) : (
@@ -186,11 +186,11 @@ export default function CampusDetail() {
       </section>
 
       <section className="bg-white border rounded-2xl p-6 space-y-3">
-        <h2 className="text-xl font-bold">Campus Facts</h2>
+        <h2 className="text-xl font-bold text-gray-900">Campus Facts</h2>
         {loading && <div>Loading…</div>}
         {error && <div className="text-red-700">{error}</div>}
         {!loading && !error && row && (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-900">
             {Object.entries(row)
               .filter(([k]) => !hiddenKeys.has(normKey(k)))
               .map(([k, v]) => {
@@ -206,9 +206,9 @@ export default function CampusDetail() {
                 }
 
                 return (
-                  <div key={k} className="bg-gray-50 border rounded-xl px-3 py-2">
-                    <div className="text-gray-600">{title}</div>
-                    <div className="font-medium break-words">{String(value)}</div>
+                  <div key={k} className="bg-gray-50 border rounded-xl px-3 py-2 text-gray-900">
+                    <div className="font-semibold">{title}</div>
+                    <div className="font-medium break-words text-gray-900">{String(value)}</div>
                   </div>
                 );
               })}

--- a/src/pages/CampusDetail.jsx
+++ b/src/pages/CampusDetail.jsx
@@ -133,7 +133,7 @@ export default function CampusDetail() {
       <header className="bg-white border rounded-2xl p-6">
         <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
           <div>
-            <h1 className="text-3xl font-extrabold tracking-tight">{name}</h1>
+            <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">{name}</h1>
             {(campusGrade || Number.isFinite(campusScore)) && (
               <div className="mt-3 flex items-center gap-2">
                 <span className="font-bold">Campus Grade</span>

--- a/src/pages/DistrictDetail.jsx
+++ b/src/pages/DistrictDetail.jsx
@@ -420,7 +420,7 @@ export default function DistrictDetail() {
             <p className="text-gray-600 mt-1">{county}</p>
             {(districtGrade || Number.isFinite(districtScore)) && (
               <div className="mt-3 flex items-center gap-2">
-                <span className="font-bold">TEA's District Grade</span>
+                <span className="font-bold text-gray-900">TEA's District Grade</span>
                 <GradeScorePill grade={districtGrade} score={districtScore} />
               </div>
             )}
@@ -471,14 +471,14 @@ export default function DistrictDetail() {
       />
 
       <section className="bg-white border rounded-2xl p-6 space-y-3">
-        <h2 className="text-xl font-bold">District Boundary</h2>
+        <h2 className="text-xl font-bold text-gray-900">District Boundary</h2>
         {geom ? <LeafMap geom={geom} height={420} /> : <p className="text-gray-600">No geometry found.</p>}
       </section>
 
       {/* Campuses */}
       <section className="bg-white border rounded-2xl p-6 space-y-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-xl font-bold">Campuses</h2>
+          <h2 className="text-xl font-bold text-gray-900">Campuses</h2>
           <div className="text-sm text-gray-500">
             {filteredCampuses.length
               ? `${filteredCampuses.length} campus${filteredCampuses.length === 1 ? "" : "es"}`

--- a/src/pages/DistrictDetail.jsx
+++ b/src/pages/DistrictDetail.jsx
@@ -416,7 +416,7 @@ export default function DistrictDetail() {
       <header className="bg-white border rounded-2xl p-6">
         <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
           <div>
-            <h1 className="text-3xl font-extrabold tracking-tight">{displayName}</h1>
+            <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">{displayName}</h1>
             <p className="text-gray-600 mt-1">{county}</p>
             {(districtGrade || Number.isFinite(districtScore)) && (
               <div className="mt-3 flex items-center gap-2">
@@ -426,7 +426,7 @@ export default function DistrictDetail() {
             )}
           </div>
 
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2 min-w-0">
             <StatPill label="Enrollment" value={Number.isNaN(enrollment) ? "—" : num.format(enrollment)} />
             <StatPill label="Per-Pupil Spending" value={Number.isNaN(perStudent) ? "—" : usd.format(perStudent)} />
             <StatPill label="Total District Spending" value={Number.isNaN(totalSpending) ? "—" : usd.format(totalSpending)} />

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -164,10 +164,25 @@ a:hover { text-decoration: underline; }
   letter-spacing: -0.01em;
   font-variant-numeric: tabular-nums;
   font-weight: 700;
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: normal;
 }
 .kpi .trend.up { color: var(--success-500); }
 .kpi .trend.down { color: var(--danger-500); }
 .kpi .trend.flat { color: var(--text-muted); }
+
+/* Stat pill and KPI safety */
+.stat-pill { min-width: 0; max-width: 100%; }
+.stat-pill p { margin: 0; }
+.stat-pill__value {
+  max-width: 100%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  line-height: 1.1;
+}
 
 .hero {
   padding: clamp(3rem, 6vw, 6rem) 1rem;

--- a/src/ui/StatPill.jsx
+++ b/src/ui/StatPill.jsx
@@ -12,9 +12,11 @@ export default function StatPill({ label, value, color = "gray", boldLabel = fal
   const labelCls = boldLabel ? "text-gray-900 font-semibold" : "text-gray-900";
 
   return (
-    <div className={`rounded-xl border px-3 py-2 text-sm text-gray-900 ${cls}`}>
+    <div className={`stat-pill rounded-xl border px-3 py-2 text-sm text-gray-900 ${cls}`}>
       <p className={labelCls}>{label}</p>
-      <p className="font-bold text-gray-900">{value}</p>
+      <p className="stat-pill__value font-bold text-gray-900 tabular-nums leading-tight whitespace-normal break-words max-w-full">
+        {value}
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update StatPill markup to add global classes and wrapping-friendly typography utilities
- add global styles to allow pills and KPI values to wrap safely without overflow
- darken district and campus detail titles and allow pill containers to shrink within flex rows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4420de6b8832ba14ad281d1bffbf0