### PR TITLE
feat(campus): add Campus Finances section to CampusDetail

### DIFF
--- a/src/components/CampusCompensationChart.jsx
+++ b/src/components/CampusCompensationChart.jsx
@@ -1,0 +1,229 @@
+import React from "react";
+import { usd } from "../lib/format";
+
+/**
+ * Two-slice compensation donut for CampusDetail. Mirrors the geometry,
+ * hover behavior, and legend-card pattern of DistrictSpendingPie, but is
+ * scoped to teacher vs admin compensation only.
+ */
+
+const SIZE = 300;
+const RADIUS = SIZE / 2;
+const INNER_RADIUS = RADIUS * 0.6;
+const LIGHTEN_DELTA = 0.1;
+
+const TEACHER_COLOR = "#0072B2"; // --viz-1
+const ADMIN_COLOR = "#E69F00";   // --viz-2
+
+const lighten = (hex, delta = LIGHTEN_DELTA) => {
+  const normalized = hex.startsWith("#") ? hex.slice(1) : hex;
+  if (normalized.length !== 6) return hex;
+  const n = parseInt(normalized, 16);
+  const r = (n >> 16) & 0xff;
+  const g = (n >> 8) & 0xff;
+  const b = n & 0xff;
+  const lc = (c) => Math.min(255, Math.round(c + (255 - c) * delta));
+  return `#${((lc(r) << 16) | (lc(g) << 8) | lc(b)).toString(16).padStart(6, "0")}`;
+};
+
+const polarToCartesian = (cx, cy, radius, angleDeg) => {
+  const angleRad = ((angleDeg - 90) * Math.PI) / 180;
+  return { x: cx + radius * Math.cos(angleRad), y: cy + radius * Math.sin(angleRad) };
+};
+
+const describeDonutArc = (cx, cy, outerR, innerR, startAngle, endAngle) => {
+  const largeArcFlag = endAngle - startAngle <= 180 ? 0 : 1;
+  const outerStart = polarToCartesian(cx, cy, outerR, endAngle);
+  const outerEnd = polarToCartesian(cx, cy, outerR, startAngle);
+  const innerStart = polarToCartesian(cx, cy, innerR, startAngle);
+  const innerEnd = polarToCartesian(cx, cy, innerR, endAngle);
+  return [
+    "M", outerStart.x, outerStart.y,
+    "A", outerR, outerR, 0, largeArcFlag, 0, outerEnd.x, outerEnd.y,
+    "L", innerStart.x, innerStart.y,
+    "A", innerR, innerR, 0, largeArcFlag, 1, innerEnd.x, innerEnd.y,
+    "Z",
+  ].join(" ");
+};
+
+export default function CampusCompensationChart({ teacherComp, adminComp }) {
+  const chartRef = React.useRef(null);
+  const [activeId, setActiveId] = React.useState(null);
+  const [tooltip, setTooltip] = React.useState(null);
+
+  const { slices, total } = React.useMemo(() => {
+    const raw = [
+      { id: "teacher", label: "Teacher compensation", value: teacherComp, color: TEACHER_COLOR },
+      { id: "admin",   label: "Admin compensation",   value: adminComp,   color: ADMIN_COLOR },
+    ].filter((s) => Number.isFinite(s.value) && s.value > 0);
+
+    const t = raw.reduce((sum, s) => sum + s.value, 0);
+    if (!t) return { slices: [], total: 0 };
+
+    let currentAngle = -90;
+    const built = raw.map((s) => {
+      const percent = (s.value / t) * 100;
+      const angle = (percent / 100) * 360;
+      const startAngle = currentAngle;
+      const endAngle = currentAngle + angle;
+      currentAngle = endAngle;
+      return {
+        ...s,
+        percent,
+        startAngle,
+        endAngle,
+        labelText: `${s.label} ${percent.toFixed(1)} percent`,
+        tooltipText: `${usd.format(s.value)} • ${percent.toFixed(1)} percent`,
+      };
+    });
+    return { slices: built, total: t };
+  }, [teacherComp, adminComp]);
+
+  const handleSliceEnter = (slice) => setActiveId(slice.id);
+  const handleSliceLeave = () => {
+    setActiveId(null);
+    setTooltip(null);
+  };
+  const handleMouseMove = (event, slice) => {
+    if (!chartRef.current) return;
+    const bounds = chartRef.current.getBoundingClientRect();
+    setTooltip({
+      id: slice.id,
+      x: event.clientX - bounds.left,
+      y: event.clientY - bounds.top,
+      text: slice.tooltipText,
+    });
+  };
+  const handleLegendFocus = (slice) => {
+    setActiveId(slice.id);
+    const rect = chartRef.current?.getBoundingClientRect();
+    const fallback = SIZE / 2;
+    setTooltip({
+      id: slice.id,
+      x: rect ? rect.width / 2 : fallback,
+      y: rect ? rect.height / 2 : fallback,
+      text: slice.tooltipText,
+    });
+  };
+  const handleLegendBlur = () => {
+    setActiveId(null);
+    setTooltip(null);
+  };
+
+  if (!slices.length) {
+    return (
+      <p className="text-sm text-[var(--text-muted)]">
+        Compensation data unavailable.
+      </p>
+    );
+  }
+
+  const ariaLabel = "Campus compensation breakdown donut chart";
+
+  return (
+    <div className="flex flex-col items-center gap-6 lg:flex-row lg:items-start lg:justify-center">
+      <div className="flex-1 flex justify-center">
+        <div
+          ref={chartRef}
+          className="relative flex items-center justify-center w-full"
+          style={{ width: "min(100%, 300px)", maxWidth: 300 }}
+        >
+          <svg
+            width={SIZE}
+            height={SIZE}
+            viewBox={`0 0 ${SIZE} ${SIZE}`}
+            role="img"
+            aria-label={ariaLabel}
+            className="w-full h-auto"
+          >
+            <title>{ariaLabel}</title>
+            {slices.map((slice) => {
+              const isActive = activeId === slice.id;
+              const fill = isActive ? lighten(slice.color) : slice.color;
+              return (
+                <g key={slice.id}>
+                  <path
+                    d={describeDonutArc(
+                      RADIUS,
+                      RADIUS,
+                      RADIUS - 2,
+                      INNER_RADIUS,
+                      slice.startAngle,
+                      slice.endAngle
+                    )}
+                    fill={fill}
+                    stroke="#ffffff"
+                    strokeWidth={1}
+                    tabIndex={0}
+                    focusable="true"
+                    role="listitem"
+                    aria-label={slice.labelText}
+                    onMouseEnter={() => handleSliceEnter(slice)}
+                    onMouseLeave={handleSliceLeave}
+                    onMouseMove={(event) => handleMouseMove(event, slice)}
+                    onFocus={() => handleLegendFocus(slice)}
+                    onBlur={handleLegendBlur}
+                  />
+                </g>
+              );
+            })}
+          </svg>
+          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
+            <span className="text-sm font-medium text-gray-500">Total comp</span>
+            <span className="text-lg font-semibold text-gray-900">
+              {usd.format(total)}
+            </span>
+          </div>
+          {tooltip && (
+            <div
+              className="pointer-events-none absolute bg-gray-900 text-white text-xs rounded-md px-2 py-1 shadow-lg"
+              style={{
+                left: Math.min(Math.max(tooltip.x, 0), chartRef.current?.offsetWidth || SIZE),
+                top: Math.min(Math.max(tooltip.y, 0), chartRef.current?.offsetHeight || SIZE),
+                transform: "translate(-50%, -120%)",
+                maxWidth: 220,
+                whiteSpace: "normal",
+              }}
+            >
+              {tooltip.text}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="w-full max-w-sm flex flex-col gap-3">
+        {slices.map((slice) => (
+          <button
+            key={slice.id}
+            type="button"
+            className={`group flex w-full items-center gap-3 rounded-2xl border px-4 py-3 text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+              activeId === slice.id
+                ? "border-blue-400 bg-blue-50"
+                : "border-gray-200 bg-white hover:bg-slate-50"
+            }`}
+            onMouseEnter={() => handleSliceEnter(slice)}
+            onMouseLeave={handleSliceLeave}
+            onFocus={() => handleLegendFocus(slice)}
+            onBlur={handleLegendBlur}
+          >
+            <span
+              className="inline-flex h-3.5 w-3.5 shrink-0 rounded-full"
+              style={{
+                backgroundColor:
+                  activeId === slice.id ? lighten(slice.color) : slice.color,
+                boxShadow: "0 0 0 1px rgba(255,255,255,0.9)",
+              }}
+              aria-hidden="true"
+            />
+            <span className="flex flex-col">
+              <span className="text-sm font-medium text-gray-900">{slice.label}</span>
+              <span className="text-xs text-gray-600">
+                {slice.percent.toFixed(1)}% · {usd.format(slice.value)}
+              </span>
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CampusFinanceSection.jsx
+++ b/src/components/CampusFinanceSection.jsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { usd } from "../lib/format";
+import { deriveCampusFinance } from "../lib/campusFinance";
+import StaffingBar from "./StaffingBar";
+import ComparisonRow from "./ComparisonRow";
+import CampusCompensationChart from "./CampusCompensationChart";
+
+const fmtUSD = (v) => (Number.isFinite(v) ? usd.format(v) : "—");
+
+function KpiTile({ label, value, sub }) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-2xl p-4 kpi">
+      <p className="label text-sm text-[var(--text-muted)]">{label}</p>
+      <p
+        className="value font-bold text-gray-900"
+        style={{
+          fontVariantNumeric: "tabular-nums",
+          fontWeight: 700,
+          fontSize: "clamp(1.35rem, 2.6vw, 1.85rem)",
+        }}
+      >
+        {value}
+      </p>
+      {sub && (
+        <p className="text-xs italic text-[var(--text-muted)] mt-1">{sub}</p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Campus Finances — a compelling campus-level financial profile section
+ * rendered between the header StatPills and the Campus Location map on
+ * CampusDetail.
+ */
+export default function CampusFinanceSection({
+  row,
+  fields,
+  districtRow,
+  districtFields,
+  campusName,
+}) {
+  const fin = React.useMemo(
+    () => deriveCampusFinance({ row, fields, districtRow, districtFields }),
+    [row, fields, districtRow, districtFields]
+  );
+
+  const hasDistrict = !!districtRow && !!districtFields;
+  const hasAnyCompensation =
+    (Number.isFinite(fin.teacherComp) && fin.teacherComp > 0) ||
+    (Number.isFinite(fin.adminComp) && fin.adminComp > 0);
+
+  return (
+    <section className="bg-white border rounded-2xl p-6 space-y-6 section-card">
+      <header className="flex items-baseline justify-between flex-wrap gap-2">
+        <h2 className="text-xl font-bold text-gray-900">Campus Finances</h2>
+        {campusName && (
+          <p className="text-sm text-[var(--text-muted)]">{campusName}</p>
+        )}
+      </header>
+
+      {/* A. KPI tiles */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <KpiTile
+          label="Est. Campus Spending"
+          value={fmtUSD(fin.estSpending)}
+          sub="Estimate (district per-pupil × enrollment)"
+        />
+        <KpiTile label="Avg Teacher Salary" value={fmtUSD(fin.teacherSal)} />
+        <KpiTile label="Avg Admin Salary" value={fmtUSD(fin.adminSal)} />
+      </div>
+
+      {/* B. Staffing Breakdown */}
+      <div className="space-y-3">
+        <h3 className="text-base font-semibold text-gray-900">Staffing Breakdown</h3>
+        <StaffingBar
+          teacherCount={fin.teacherCount}
+          adminCount={fin.adminCount}
+          tRatio={fin.tRatio}
+          aRatio={fin.aRatio}
+        />
+      </div>
+
+      {/* C. Compensation Split */}
+      <div className="space-y-3">
+        <h3 className="text-base font-semibold text-gray-900">Compensation Split</h3>
+        {hasAnyCompensation ? (
+          <CampusCompensationChart
+            teacherComp={fin.teacherComp}
+            adminComp={fin.adminComp}
+          />
+        ) : (
+          <p className="text-sm text-[var(--text-muted)]">
+            Compensation data unavailable.
+          </p>
+        )}
+      </div>
+
+      {/* D. How This Campus Compares */}
+      {hasDistrict && (
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold text-gray-900">
+            How This Campus Compares
+          </h3>
+          <div>
+            <ComparisonRow
+              label="Teacher Salary"
+              campus={fin.teacherSal}
+              district={fin.districtTeachSal}
+              kind="usd"
+              higherIsBetter
+            />
+            <ComparisonRow
+              label={
+                <>
+                  Principal / Admin Salary
+                  <sup className="ml-0.5">†</sup>
+                </>
+              }
+              campus={fin.adminSal}
+              district={fin.districtPrincSal}
+              kind="usd"
+              higherIsBetter
+            />
+          </div>
+        </div>
+      )}
+
+      {/* E. Disclaimer footnote */}
+      <p className="text-xs italic text-[var(--text-muted)]">
+        Spending estimate based on district per-pupil figure. Campus-level
+        expenditure data coming soon.
+        {hasDistrict && (
+          <>
+            {" "}
+            <span aria-hidden="true">†</span> District-level salary data tracks
+            principals only; campus admin includes assistant principals.
+          </>
+        )}
+      </p>
+    </section>
+  );
+}

--- a/src/components/CampusFinanceSection.jsx
+++ b/src/components/CampusFinanceSection.jsx
@@ -1,29 +1,31 @@
 import React from "react";
 import { usd } from "../lib/format";
 import { deriveCampusFinance } from "../lib/campusFinance";
+import AnimatedValue from "../ui/AnimatedValue";
 import StaffingBar from "./StaffingBar";
 import ComparisonRow from "./ComparisonRow";
 import CampusCompensationChart from "./CampusCompensationChart";
 
-const fmtUSD = (v) => (Number.isFinite(v) ? usd.format(v) : "—");
+const fmtUSD = (v) =>
+  Number.isFinite(v)
+    ? usd.format(Math.round(v))
+    : "—";
 
-function KpiTile({ label, value, sub }) {
+function KpiTile({ label, rawValue, valueFormatter, sub, accent }) {
+  const hasValue = Number.isFinite(rawValue);
+  const accentClass =
+    accent === "accent" ? "kpi--accent" : accent === "brand" ? "kpi--brand" : "";
   return (
-    <div className="bg-white border border-gray-200 rounded-2xl p-4 kpi">
-      <p className="label text-sm text-[var(--text-muted)]">{label}</p>
-      <p
-        className="value font-bold text-gray-900"
-        style={{
-          fontVariantNumeric: "tabular-nums",
-          fontWeight: 700,
-          fontSize: "clamp(1.35rem, 2.6vw, 1.85rem)",
-        }}
-      >
-        {value}
-      </p>
-      {sub && (
-        <p className="text-xs italic text-[var(--text-muted)] mt-1">{sub}</p>
-      )}
+    <div className={`card kpi kpi--dense ${accentClass}`}>
+      <span className="label">{label}</span>
+      <span className="value">
+        {hasValue ? (
+          <AnimatedValue value={rawValue} format={valueFormatter} />
+        ) : (
+          "—"
+        )}
+      </span>
+      {sub && <span className="sub">{sub}</span>}
     </div>
   );
 }
@@ -51,28 +53,46 @@ export default function CampusFinanceSection({
     (Number.isFinite(fin.adminComp) && fin.adminComp > 0);
 
   return (
-    <section className="bg-white border rounded-2xl p-6 space-y-6 section-card">
-      <header className="flex items-baseline justify-between flex-wrap gap-2">
-        <h2 className="text-xl font-bold text-gray-900">Campus Finances</h2>
-        {campusName && (
-          <p className="text-sm text-[var(--text-muted)]">{campusName}</p>
-        )}
+    <section className="section-card space-y-6">
+      <header className="flex items-start justify-between flex-wrap gap-3">
+        <div>
+          <span className="eyebrow eyebrow--brand">Financials</span>
+          <h2 className="section-title mt-1">Campus Finances</h2>
+          {campusName && (
+            <p className="mt-1 text-sm text-[var(--text-muted)]">{campusName}</p>
+          )}
+        </div>
       </header>
 
       {/* A. KPI tiles */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <KpiTile
           label="Est. Campus Spending"
-          value={fmtUSD(fin.estSpending)}
-          sub="Estimate (district per-pupil × enrollment)"
+          rawValue={fin.estSpending}
+          valueFormatter={fmtUSD}
+          sub="Estimate · district per-pupil × enrollment"
+          accent="accent"
         />
-        <KpiTile label="Avg Teacher Salary" value={fmtUSD(fin.teacherSal)} />
-        <KpiTile label="Avg Admin Salary" value={fmtUSD(fin.adminSal)} />
+        <KpiTile
+          label="Avg Teacher Salary"
+          rawValue={fin.teacherSal}
+          valueFormatter={fmtUSD}
+          accent="brand"
+        />
+        <KpiTile
+          label="Avg Admin Salary"
+          rawValue={fin.adminSal}
+          valueFormatter={fmtUSD}
+          accent="brand"
+        />
       </div>
 
       {/* B. Staffing Breakdown */}
-      <div className="space-y-3">
-        <h3 className="text-base font-semibold text-gray-900">Staffing Breakdown</h3>
+      <div className="space-y-3 pt-1">
+        <h3 className="subsection-title">
+          <span className="subsection-title__dot" />
+          Staffing Breakdown
+        </h3>
         <StaffingBar
           teacherCount={fin.teacherCount}
           adminCount={fin.adminCount}
@@ -82,8 +102,14 @@ export default function CampusFinanceSection({
       </div>
 
       {/* C. Compensation Split */}
-      <div className="space-y-3">
-        <h3 className="text-base font-semibold text-gray-900">Compensation Split</h3>
+      <div className="space-y-3 pt-1">
+        <h3 className="subsection-title">
+          <span
+            className="subsection-title__dot"
+            style={{ background: "var(--viz-1)" }}
+          />
+          Compensation Split
+        </h3>
         {hasAnyCompensation ? (
           <CampusCompensationChart
             teacherComp={fin.teacherComp}
@@ -98,8 +124,12 @@ export default function CampusFinanceSection({
 
       {/* D. How This Campus Compares */}
       {hasDistrict && (
-        <div className="space-y-1">
-          <h3 className="text-base font-semibold text-gray-900">
+        <div className="space-y-3 pt-1">
+          <h3 className="subsection-title">
+            <span
+              className="subsection-title__dot"
+              style={{ background: "var(--accent-500)" }}
+            />
             How This Campus Compares
           </h3>
           <div>
@@ -127,9 +157,11 @@ export default function CampusFinanceSection({
       )}
 
       {/* E. Disclaimer footnote */}
-      <p className="text-xs italic text-[var(--text-muted)]">
-        Spending estimate based on district per-pupil figure. Campus-level
-        expenditure data coming soon.
+      <p className="text-[11px] leading-relaxed text-[var(--text-muted)] pt-2 border-t border-[var(--border)]">
+        <span className="font-semibold">Methodology.</span> Estimated campus
+        spending derives from the parent district's per-pupil figure multiplied
+        by campus enrollment; actual campus-level expenditure data is coming
+        soon.
         {hasDistrict && (
           <>
             {" "}

--- a/src/components/ChartDownloadButton.jsx
+++ b/src/components/ChartDownloadButton.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { downloadContainerSvgAsPng } from "../lib/exportChart";
+
+/**
+ * A small icon button that exports the first SVG found inside the referenced
+ * container as a PNG. Used on every chart section in DistrictSpendingTimeline.
+ *
+ * Props:
+ *   targetRef  — React ref pointing to a container element that holds an SVG
+ *   filename   — filename (without extension) for the downloaded PNG
+ *   children   — optional label text, defaults to "PNG"
+ */
+export default function ChartDownloadButton({ targetRef, filename, children }) {
+  const [busy, setBusy] = React.useState(false);
+
+  const onClick = async () => {
+    if (!targetRef?.current || busy) return;
+    setBusy(true);
+    try {
+      await downloadContainerSvgAsPng(targetRef.current, filename);
+    } catch (e) {
+      console.warn("[ChartDownloadButton] export failed:", e?.message || e);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className="icon-btn"
+      onClick={onClick}
+      disabled={busy}
+      aria-label="Download chart as PNG"
+      title="Download chart as PNG"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="13"
+        height="13"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <polyline points="7 10 12 15 17 10" />
+        <line x1="12" y1="15" x2="12" y2="3" />
+      </svg>
+      {children || "PNG"}
+    </button>
+  );
+}

--- a/src/components/ComparisonRow.jsx
+++ b/src/components/ComparisonRow.jsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { usd, num } from "../lib/format";
+
+const CHIP_STYLES = {
+  gray: "bg-gray-50 border-gray-200 text-gray-700",
+  green: "bg-green-100 border-green-200 text-green-800",
+  yellow: "bg-yellow-100 border-yellow-200 text-yellow-800",
+  amber: "bg-amber-100 border-amber-200 text-amber-800",
+  red: "bg-red-100 border-red-200 text-red-800",
+};
+
+const fmt = (v, kind) => {
+  if (!Number.isFinite(v)) return "—";
+  if (kind === "usd") return usd.format(v);
+  if (kind === "pct") return `${(v * 100).toFixed(1)}%`;
+  return num.format(v);
+};
+
+const fmtDelta = (v, kind) => {
+  if (!Number.isFinite(v)) return "—";
+  const sign = v >= 0 ? "+" : "−";
+  const abs = Math.abs(v);
+  if (kind === "usd") return `${sign}${usd.format(abs)}`;
+  if (kind === "pct") return `${sign}${(abs * 100).toFixed(1)}%`;
+  return `${sign}${num.format(abs)}`;
+};
+
+/**
+ * Horizontal comparison row showing a single metric for the campus vs the
+ * district average, with a color-coded delta chip.
+ *
+ * Props:
+ *   label            — metric label (string, may include footnote marker)
+ *   campus, district — numeric values (may be NaN)
+ *   kind             — "usd" | "num" | "pct"
+ *   higherIsBetter   — default true; flips green/red polarity when false
+ */
+export default function ComparisonRow({
+  label,
+  campus,
+  district,
+  kind = "usd",
+  higherIsBetter = true,
+}) {
+  const hasBoth = Number.isFinite(campus) && Number.isFinite(district);
+  const delta = hasBoth ? campus - district : NaN;
+  const pctDelta = hasBoth && district !== 0 ? (delta / district) * 100 : NaN;
+
+  let color = "gray";
+  let chipText = "no comparison";
+  let arrow = "";
+
+  if (hasBoth) {
+    const absPct = Number.isFinite(pctDelta) ? Math.abs(pctDelta) : 0;
+    const favorable = higherIsBetter ? delta >= 0 : delta <= 0;
+
+    if (absPct < 2) {
+      color = "gray";
+    } else if (favorable) {
+      color = absPct > 10 ? "green" : "yellow";
+    } else {
+      color = absPct > 10 ? "red" : "amber";
+    }
+
+    arrow = delta === 0 ? "" : delta > 0 ? "▲" : "▼";
+    const pctText = Number.isFinite(pctDelta)
+      ? ` (${pctDelta >= 0 ? "+" : "−"}${Math.abs(pctDelta).toFixed(1)}%)`
+      : "";
+    chipText = `${fmtDelta(delta, kind)}${pctText}`;
+  }
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 py-3 border-b border-gray-100 last:border-0">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900">{label}</p>
+        <p className="text-xs text-[var(--text-muted)] tabular-nums">
+          Campus: <span className="text-gray-900 font-semibold">{fmt(campus, kind)}</span>
+          <span className="mx-2">·</span>
+          District avg: <span className="text-gray-900 font-semibold">{fmt(district, kind)}</span>
+        </p>
+      </div>
+      <div
+        className={`shrink-0 inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-semibold tabular-nums ${CHIP_STYLES[color]}`}
+      >
+        {arrow && <span aria-hidden="true">{arrow}</span>}
+        <span>{chipText}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CompositionShiftChart.jsx
+++ b/src/components/CompositionShiftChart.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  fmtUSD0,
+  MACRO_CATEGORIES,
+  useChartColors,
+  tooltipStyle,
+} from "../lib/spendingHelpers";
+
+const CHART_H = 200;
+
+/**
+ * 100% stacked horizontal bars — one bar per year, segments for each macro
+ * spending category. Shows how the composition of spending shifts over time.
+ */
+export default function CompositionShiftChart({ macroSeries }) {
+  const colors = useChartColors();
+
+  if (!macroSeries || !macroSeries.length) {
+    return (
+      <p className="text-sm text-[var(--text-muted)]">
+        No composition data available.
+      </p>
+    );
+  }
+
+  // Convert absolute dollars to percentages (0-100) per year.
+  const data = macroSeries.map((row) => {
+    const total = row.total || 0;
+    const out = { year: row.year, _rawTotal: total };
+    for (const cat of MACRO_CATEGORIES) {
+      out[cat.id] = total > 0 ? ((row[cat.id] || 0) / total) * 100 : 0;
+      out[`${cat.id}_usd`] = row[cat.id] || 0;
+    }
+    return out;
+  });
+
+  // Dynamic height: enough room per year bar, clamped at 200px minimum.
+  const h = Math.max(CHART_H, data.length * 48 + 60);
+
+  return (
+    <ResponsiveContainer width="100%" height={h}>
+      <BarChart
+        data={data}
+        layout="vertical"
+        margin={{ top: 8, right: 16, bottom: 12, left: 8 }}
+      >
+        <XAxis
+          type="number"
+          domain={[0, 100]}
+          tickFormatter={(v) => `${Math.round(v)}%`}
+          tick={{ fontSize: 11, fill: colors.text }}
+          stroke={colors.border}
+        />
+        <YAxis
+          type="category"
+          dataKey="year"
+          tick={{ fontSize: 12, fill: colors.text }}
+          stroke={colors.border}
+          width={48}
+        />
+        <Tooltip
+          formatter={(value, name, ctx) => {
+            const pct = Number.isFinite(value) ? `${value.toFixed(1)}%` : "—";
+            const usd = ctx?.payload?.[`${ctx?.dataKey}_usd`];
+            const raw = Number.isFinite(usd) ? ` · ${fmtUSD0(usd)}` : "";
+            const label =
+              MACRO_CATEGORIES.find((c) => c.id === name)?.label || name;
+            return [`${pct}${raw}`, label];
+          }}
+          labelFormatter={(y) => `Year ${y}`}
+          contentStyle={tooltipStyle(colors)}
+        />
+        <Legend
+          verticalAlign="top"
+          align="left"
+          wrapperStyle={{ fontSize: 12 }}
+          formatter={(name) =>
+            MACRO_CATEGORIES.find((c) => c.id === name)?.label || name
+          }
+        />
+        {MACRO_CATEGORIES.map((cat, i) => (
+          <Bar
+            key={cat.id}
+            dataKey={cat.id}
+            stackId="comp"
+            fill={colors.palette[i % colors.palette.length]}
+            isAnimationActive={false}
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/CompositionShiftChart.jsx
+++ b/src/components/CompositionShiftChart.jsx
@@ -15,14 +15,91 @@ import {
   tooltipStyle,
 } from "../lib/spendingHelpers";
 
-const CHART_H = 200;
+const CHART_H = 220;
+
+function useIsBelow(breakpoint) {
+  const [is, setIs] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const sync = () => setIs(mql.matches);
+    sync();
+    mql.addEventListener?.("change", sync);
+    return () => mql.removeEventListener?.("change", sync);
+  }, [breakpoint]);
+  return is;
+}
+
+function prefersReducedMotion() {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/** Below 768px the horizontal bars become unreadable — swap to a compact table. */
+function CompositionTable({ macroSeries, colors }) {
+  const sorted = [...macroSeries].sort((a, b) => b.year - a.year);
+  return (
+    <div className="data-table">
+      <div className="data-table__scroller">
+        <table className="w-full text-xs">
+          <thead>
+            <tr>
+              <th className="text-left">Year</th>
+              {MACRO_CATEGORIES.map((c) => (
+                <th key={c.id} className="align-right">
+                  <span
+                    className="inline-block h-2 w-2 rounded-full mr-1 align-middle"
+                    style={{
+                      background:
+                        colors.palette[
+                          MACRO_CATEGORIES.findIndex((x) => x.id === c.id) %
+                            colors.palette.length
+                        ],
+                    }}
+                    aria-hidden="true"
+                  />
+                  {c.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((row) => {
+              const total = row.total || 0;
+              return (
+                <tr key={row.year}>
+                  <td className="tabular-nums">{row.year}</td>
+                  {MACRO_CATEGORIES.map((c) => {
+                    const pct =
+                      total > 0 ? ((row[c.id] || 0) / total) * 100 : 0;
+                    return (
+                      <td
+                        key={c.id}
+                        className="align-right tabular-nums"
+                        title={fmtUSD0(row[c.id] || 0)}
+                      >
+                        {pct.toFixed(1)}%
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
 
 /**
  * 100% stacked horizontal bars — one bar per year, segments for each macro
- * spending category. Shows how the composition of spending shifts over time.
+ * spending category. Below 768px, renders as a compact percentage table.
  */
 export default function CompositionShiftChart({ macroSeries }) {
   const colors = useChartColors();
+  const isSmall = useIsBelow(768);
+  const reducedMotion = prefersReducedMotion();
 
   if (!macroSeries || !macroSeries.length) {
     return (
@@ -30,6 +107,10 @@ export default function CompositionShiftChart({ macroSeries }) {
         No composition data available.
       </p>
     );
+  }
+
+  if (isSmall) {
+    return <CompositionTable macroSeries={macroSeries} colors={colors} />;
   }
 
   // Convert absolute dollars to percentages (0-100) per year.
@@ -43,7 +124,6 @@ export default function CompositionShiftChart({ macroSeries }) {
     return out;
   });
 
-  // Dynamic height: enough room per year bar, clamped at 200px minimum.
   const h = Math.max(CHART_H, data.length * 48 + 60);
 
   return (
@@ -59,15 +139,18 @@ export default function CompositionShiftChart({ macroSeries }) {
           tickFormatter={(v) => `${Math.round(v)}%`}
           tick={{ fontSize: 11, fill: colors.text }}
           stroke={colors.border}
+          tickLine={false}
         />
         <YAxis
           type="category"
           dataKey="year"
           tick={{ fontSize: 12, fill: colors.text }}
           stroke={colors.border}
+          tickLine={false}
           width={48}
         />
         <Tooltip
+          cursor={{ fill: "rgba(12, 58, 107, 0.05)" }}
           formatter={(value, name, ctx) => {
             const pct = Number.isFinite(value) ? `${value.toFixed(1)}%` : "—";
             const usd = ctx?.payload?.[`${ctx?.dataKey}_usd`];
@@ -93,7 +176,9 @@ export default function CompositionShiftChart({ macroSeries }) {
             dataKey={cat.id}
             stackId="comp"
             fill={colors.palette[i % colors.palette.length]}
-            isAnimationActive={false}
+            isAnimationActive={!reducedMotion}
+            animationDuration={reducedMotion ? 0 : 600}
+            animationBegin={reducedMotion ? 0 : i * 60}
           />
         ))}
       </BarChart>

--- a/src/components/DistrictSpendingTimeline.jsx
+++ b/src/components/DistrictSpendingTimeline.jsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { getDistrictSpendingTimeline } from "../lib/districtSpendingTimeline";
+import SpendingKPIRow from "./SpendingKPIRow";
+import SpendingLineChart from "./SpendingLineChart";
+import TopCostCentersChart from "./TopCostCentersChart";
+import CompositionShiftChart from "./CompositionShiftChart";
+import YearDetailTable from "./YearDetailTable";
+
+/**
+ * District-scoped Spending Over Time section. Rendered on DistrictDetail
+ * between the DistrictSpendingPie and the District Boundary map.
+ *
+ * Props:
+ *   districtId   — the route param (DISTRICT_N)
+ *   districtName — display name (for the header)
+ */
+export default function DistrictSpendingTimeline({ districtId, districtName }) {
+  const [timeline, setTimeline] = React.useState(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    if (!districtId) return undefined;
+    let alive = true;
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const t = await getDistrictSpendingTimeline(districtId);
+        if (alive) setTimeline(t);
+      } catch (e) {
+        if (alive) setError(String(e?.message || e));
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [districtId]);
+
+  const subtitle =
+    districtName && String(districtName).trim()
+      ? String(districtName).trim()
+      : `District ${districtId}`;
+
+  return (
+    <section className="bg-white border rounded-2xl p-6 space-y-6 section-card">
+      <header className="flex items-baseline justify-between flex-wrap gap-2">
+        <div>
+          <h2 className="text-xl font-bold text-gray-900">Spending Over Time</h2>
+          <p className="text-sm text-[var(--text-muted)]">{subtitle}</p>
+        </div>
+        <Link
+          to="/spending"
+          className="text-sm font-medium text-[var(--brand-500)] hover:underline"
+        >
+          View full statewide trends →
+        </Link>
+      </header>
+
+      {loading && (
+        <p className="text-sm text-[var(--text-muted)]">Loading spending timeline…</p>
+      )}
+
+      {error && !loading && (
+        <p className="text-sm text-[var(--danger-500)]">
+          Could not load spending timeline: {error}
+        </p>
+      )}
+
+      {timeline && !loading && !error && (
+        <>
+          <SpendingKPIRow kpis={timeline.kpis} />
+
+          <div className="space-y-3">
+            <h3 className="text-base font-semibold text-gray-900">
+              Total Spending
+            </h3>
+            <SpendingLineChart totals={timeline.totals} />
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="text-base font-semibold text-gray-900">
+              Top Cost Centers
+            </h3>
+            <TopCostCentersChart
+              topObjects={timeline.topObjects}
+              years={timeline.years}
+            />
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="text-base font-semibold text-gray-900">
+              Spending Composition Shift
+            </h3>
+            <p className="text-xs text-[var(--text-muted)] -mt-1">
+              How each year's spending is split across macro categories.
+            </p>
+            <CompositionShiftChart macroSeries={timeline.macroSeries} />
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="text-base font-semibold text-gray-900">
+              Year-over-Year Detail
+            </h3>
+            <p className="text-xs text-[var(--text-muted)] -mt-1">
+              Click a year to expand its object-code breakdown.
+            </p>
+            <YearDetailTable
+              totals={timeline.totals}
+              byObject={timeline.byObject}
+            />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/DistrictSpendingTimeline.jsx
+++ b/src/components/DistrictSpendingTimeline.jsx
@@ -6,19 +6,26 @@ import SpendingLineChart from "./SpendingLineChart";
 import TopCostCentersChart from "./TopCostCentersChart";
 import CompositionShiftChart from "./CompositionShiftChart";
 import YearDetailTable from "./YearDetailTable";
+import Skeleton, {
+  SkeletonKPI,
+  SkeletonChart,
+  SkeletonTableRows,
+} from "../ui/Skeleton";
+import ChartDownloadButton from "./ChartDownloadButton";
 
 /**
  * District-scoped Spending Over Time section. Rendered on DistrictDetail
  * between the DistrictSpendingPie and the District Boundary map.
- *
- * Props:
- *   districtId   — the route param (DISTRICT_N)
- *   districtName — display name (for the header)
  */
 export default function DistrictSpendingTimeline({ districtId, districtName }) {
   const [timeline, setTimeline] = React.useState(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
+
+  // Refs for PNG export
+  const lineRef = React.useRef(null);
+  const barRef = React.useRef(null);
+  const compRef = React.useRef(null);
 
   React.useEffect(() => {
     if (!districtId) return undefined;
@@ -45,24 +52,27 @@ export default function DistrictSpendingTimeline({ districtId, districtName }) {
       ? String(districtName).trim()
       : `District ${districtId}`;
 
+  const safeDownloadName = (kind) =>
+    `${String(districtName || districtId)
+      .replace(/[^\w]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .slice(0, 40)}_${kind}`;
+
   return (
-    <section className="bg-white border rounded-2xl p-6 space-y-6 section-card">
-      <header className="flex items-baseline justify-between flex-wrap gap-2">
+    <section className="section-card space-y-7">
+      <header className="flex items-start justify-between flex-wrap gap-3">
         <div>
-          <h2 className="text-xl font-bold text-gray-900">Spending Over Time</h2>
-          <p className="text-sm text-[var(--text-muted)]">{subtitle}</p>
+          <span className="eyebrow eyebrow--brand">Trajectory · 2018 → 2024</span>
+          <h2 className="section-title mt-1">Spending Over Time</h2>
+          <p className="mt-1 text-sm text-[var(--text-muted)]">{subtitle}</p>
         </div>
         <Link
           to="/spending"
-          className="text-sm font-medium text-[var(--brand-500)] hover:underline"
+          className="text-sm font-semibold text-[var(--brand-500)] hover:underline whitespace-nowrap"
         >
           View full statewide trends →
         </Link>
       </header>
-
-      {loading && (
-        <p className="text-sm text-[var(--text-muted)]">Loading spending timeline…</p>
-      )}
 
       {error && !loading && (
         <p className="text-sm text-[var(--danger-500)]">
@@ -70,51 +80,123 @@ export default function DistrictSpendingTimeline({ districtId, districtName }) {
         </p>
       )}
 
-      {timeline && !loading && !error && (
-        <>
-          <SpendingKPIRow kpis={timeline.kpis} />
+      {/* -- KPIs --------------------------------------------------- */}
+      {loading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <SkeletonKPI />
+          <SkeletonKPI />
+          <SkeletonKPI />
+        </div>
+      ) : timeline ? (
+        <SpendingKPIRow kpis={timeline.kpis} />
+      ) : null}
 
-          <div className="space-y-3">
-            <h3 className="text-base font-semibold text-gray-900">
-              Total Spending
-            </h3>
+      {/* -- Line chart --------------------------------------------- */}
+      <div className="space-y-3 pt-1">
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <h3 className="subsection-title">
+            <span className="subsection-title__dot" />
+            Total Spending
+          </h3>
+          {!loading && timeline && (
+            <ChartDownloadButton
+              targetRef={lineRef}
+              filename={safeDownloadName("total_spending")}
+            />
+          )}
+        </div>
+        <div ref={lineRef} className="chart-frame">
+          {loading ? (
+            <SkeletonChart height={320} />
+          ) : timeline ? (
             <SpendingLineChart totals={timeline.totals} />
-          </div>
+          ) : null}
+        </div>
+      </div>
 
-          <div className="space-y-3">
-            <h3 className="text-base font-semibold text-gray-900">
-              Top Cost Centers
-            </h3>
+      {/* -- Top cost centers --------------------------------------- */}
+      <div className="space-y-3 pt-1">
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <h3 className="subsection-title">
+            <span
+              className="subsection-title__dot"
+              style={{ background: "var(--viz-2)" }}
+            />
+            Top Cost Centers
+          </h3>
+          {!loading && timeline && (
+            <ChartDownloadButton
+              targetRef={barRef}
+              filename={safeDownloadName("top_cost_centers")}
+            />
+          )}
+        </div>
+        <div ref={barRef} className="chart-frame">
+          {loading ? (
+            <SkeletonChart height={360} />
+          ) : timeline ? (
             <TopCostCentersChart
               topObjects={timeline.topObjects}
               years={timeline.years}
             />
-          </div>
+          ) : null}
+        </div>
+      </div>
 
-          <div className="space-y-3">
-            <h3 className="text-base font-semibold text-gray-900">
+      {/* -- Composition shift --------------------------------------- */}
+      <div className="space-y-3 pt-1">
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <div>
+            <h3 className="subsection-title">
+              <span
+                className="subsection-title__dot"
+                style={{ background: "var(--viz-4)" }}
+              />
               Spending Composition Shift
             </h3>
-            <p className="text-xs text-[var(--text-muted)] -mt-1">
-              How each year's spending is split across macro categories.
+            <p className="text-xs text-[var(--text-muted)] mt-1">
+              How each year's spending splits across macro categories.
             </p>
-            <CompositionShiftChart macroSeries={timeline.macroSeries} />
           </div>
-
-          <div className="space-y-3">
-            <h3 className="text-base font-semibold text-gray-900">
-              Year-over-Year Detail
-            </h3>
-            <p className="text-xs text-[var(--text-muted)] -mt-1">
-              Click a year to expand its object-code breakdown.
-            </p>
-            <YearDetailTable
-              totals={timeline.totals}
-              byObject={timeline.byObject}
+          {!loading && timeline && (
+            <ChartDownloadButton
+              targetRef={compRef}
+              filename={safeDownloadName("composition_shift")}
             />
-          </div>
-        </>
-      )}
+          )}
+        </div>
+        <div ref={compRef} className="chart-frame">
+          {loading ? (
+            <Skeleton variant="block" height={220} />
+          ) : timeline ? (
+            <CompositionShiftChart macroSeries={timeline.macroSeries} />
+          ) : null}
+        </div>
+      </div>
+
+      {/* -- Detail table -------------------------------------------- */}
+      <div className="space-y-3 pt-1">
+        <div>
+          <h3 className="subsection-title">
+            <span
+              className="subsection-title__dot"
+              style={{ background: "var(--accent-500)" }}
+            />
+            Year-over-Year Detail
+          </h3>
+          <p className="text-xs text-[var(--text-muted)] mt-1">
+            Click a year to expand its object-code breakdown.
+          </p>
+        </div>
+        {loading ? (
+          <SkeletonTableRows rows={4} />
+        ) : timeline ? (
+          <YearDetailTable
+            totals={timeline.totals}
+            byObject={timeline.byObject}
+          />
+        ) : null}
+      </div>
     </section>
   );
 }

--- a/src/components/SpendingKPIRow.jsx
+++ b/src/components/SpendingKPIRow.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import AnimatedValue from "../ui/AnimatedValue";
 import {
   fmtSignedUSDShort,
   fmtSignedPct,
@@ -11,9 +12,9 @@ function trendClass(delta) {
 }
 
 function KpiCard({ label, change, valueFormatter }) {
-  if (!change) {
+  if (!change || !Number.isFinite(change.delta)) {
     return (
-      <div className="card stat-card kpi">
+      <div className="card kpi kpi--dense">
         <span className="label">{label}</span>
         <span className="value">—</span>
       </div>
@@ -23,17 +24,18 @@ function KpiCard({ label, change, valueFormatter }) {
   const tc = trendClass(delta);
   const arrow = tc === "up" ? "▲" : tc === "down" ? "▼" : "·";
   return (
-    <div className="card stat-card kpi">
+    <div className="card kpi kpi--dense">
       <span className="label">{label}</span>
-      <span className="value">{valueFormatter(delta)}</span>
-      <span className={`trend ${tc}`} style={{ fontSize: "0.9rem", fontWeight: 600 }}>
-        <span aria-hidden="true">{arrow}</span> {fmtSignedPct(pct)}
+      <span className="value">
+        <AnimatedValue value={delta} format={valueFormatter} />
+      </span>
+      <span className={`trend ${tc}`}>
+        <span aria-hidden="true">{arrow}</span>
+        {fmtSignedPct(pct)}
       </span>
       {Number.isFinite(startYear) && Number.isFinite(endYear) && (
-        <span
-          style={{ fontSize: "0.75rem", color: "var(--text-muted)" }}
-        >
-          {startYear}→{endYear}
+        <span className="sub">
+          {startYear} → {endYear}
         </span>
       )}
     </div>

--- a/src/components/SpendingKPIRow.jsx
+++ b/src/components/SpendingKPIRow.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import {
+  fmtSignedUSDShort,
+  fmtSignedPct,
+  fmtSignedInt,
+} from "../lib/spendingHelpers";
+
+function trendClass(delta) {
+  if (!Number.isFinite(delta) || delta === 0) return "flat";
+  return delta > 0 ? "up" : "down";
+}
+
+function KpiCard({ label, change, valueFormatter }) {
+  if (!change) {
+    return (
+      <div className="card stat-card kpi">
+        <span className="label">{label}</span>
+        <span className="value">—</span>
+      </div>
+    );
+  }
+  const { delta, pct, startYear, endYear } = change;
+  const tc = trendClass(delta);
+  const arrow = tc === "up" ? "▲" : tc === "down" ? "▼" : "·";
+  return (
+    <div className="card stat-card kpi">
+      <span className="label">{label}</span>
+      <span className="value">{valueFormatter(delta)}</span>
+      <span className={`trend ${tc}`} style={{ fontSize: "0.9rem", fontWeight: 600 }}>
+        <span aria-hidden="true">{arrow}</span> {fmtSignedPct(pct)}
+      </span>
+      {Number.isFinite(startYear) && Number.isFinite(endYear) && (
+        <span
+          style={{ fontSize: "0.75rem", color: "var(--text-muted)" }}
+        >
+          {startYear}→{endYear}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Three-card KPI row showing Total Change, Per-Student Change, Enrollment Change.
+ * Expects the `kpis` object returned by getDistrictSpendingTimeline().
+ */
+export default function SpendingKPIRow({ kpis }) {
+  if (!kpis) return null;
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <KpiCard
+        label="Total Change"
+        change={kpis.totalChange}
+        valueFormatter={fmtSignedUSDShort}
+      />
+      <KpiCard
+        label="Per-Student Change"
+        change={kpis.perStudentChange}
+        valueFormatter={fmtSignedUSDShort}
+      />
+      <KpiCard
+        label="Enrollment Change"
+        change={kpis.enrollmentChange}
+        valueFormatter={fmtSignedInt}
+      />
+    </div>
+  );
+}

--- a/src/components/SpendingLineChart.jsx
+++ b/src/components/SpendingLineChart.jsx
@@ -1,0 +1,113 @@
+import React from "react";
+import {
+  ComposedChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  fmtShortUSD,
+  fmtUSD0,
+  useChartColors,
+  tooltipStyle,
+} from "../lib/spendingHelpers";
+
+const CHART_H = 320;
+
+/**
+ * Total Spending Over Time.
+ *
+ * Line 1 = this district (bold, --viz-1), with a 10%-opacity area fill underneath.
+ * Line 2 = statewide average per district (dashed, --viz-8).
+ */
+export default function SpendingLineChart({ totals }) {
+  const colors = useChartColors();
+
+  if (!totals || !totals.length) {
+    return (
+      <p className="text-sm text-[var(--text-muted)]">
+        No spending timeline data available.
+      </p>
+    );
+  }
+
+  const data = totals.map((t) => ({
+    year: t.year,
+    district: Number.isFinite(t.totalSpending) ? t.totalSpending : null,
+    statewide: Number.isFinite(t.statewidePerDistrict)
+      ? t.statewidePerDistrict
+      : null,
+  }));
+
+  return (
+    <div style={{ width: "100%" }}>
+      <ResponsiveContainer width="100%" height={CHART_H}>
+        <ComposedChart
+          data={data}
+          margin={{ top: 8, right: 16, bottom: 12, left: 8 }}
+        >
+          <defs>
+            <linearGradient id="districtFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={colors.total} stopOpacity={0.18} />
+              <stop offset="100%" stopColor={colors.total} stopOpacity={0.02} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid stroke={colors.grid} strokeDasharray="3 3" />
+          <XAxis
+            dataKey="year"
+            tick={{ fontSize: 12, fill: colors.text }}
+            stroke={colors.border}
+          />
+          <YAxis
+            tickFormatter={fmtShortUSD}
+            tick={{ fontSize: 12, fill: colors.text }}
+            stroke={colors.border}
+            width={70}
+          />
+          <Tooltip
+            formatter={(value, name) => [
+              Number.isFinite(value) ? fmtUSD0(value) : "—",
+              name,
+            ]}
+            labelFormatter={(y) => `Year ${y}`}
+            contentStyle={tooltipStyle(colors)}
+          />
+          <Legend verticalAlign="top" align="left" wrapperStyle={{ fontSize: 12 }} />
+          <Area
+            type="monotone"
+            dataKey="district"
+            name="This district"
+            stroke="none"
+            fill="url(#districtFill)"
+            isAnimationActive={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="district"
+            name="This district"
+            stroke={colors.total}
+            strokeWidth={2.5}
+            dot={{ r: 4, strokeWidth: 1, stroke: colors.surface, fill: colors.total }}
+            activeDot={{ r: 6 }}
+            isAnimationActive={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="statewide"
+            name="Statewide avg / district"
+            stroke={colors.statewide}
+            strokeWidth={2}
+            strokeDasharray="6 4"
+            dot={{ r: 3, strokeWidth: 1, stroke: colors.surface, fill: colors.statewide }}
+            isAnimationActive={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/SpendingLineChart.jsx
+++ b/src/components/SpendingLineChart.jsx
@@ -17,16 +17,35 @@ import {
   tooltipStyle,
 } from "../lib/spendingHelpers";
 
-const CHART_H = 320;
+const CHART_H_DEFAULT = 320;
+const CHART_H_MOBILE = 240;
+
+function useIsMobile(breakpoint = 640) {
+  const [is, setIs] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const sync = () => setIs(mql.matches);
+    sync();
+    mql.addEventListener?.("change", sync);
+    return () => mql.removeEventListener?.("change", sync);
+  }, [breakpoint]);
+  return is;
+}
+
+function prefersReducedMotion() {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
 
 /**
- * Total Spending Over Time.
- *
- * Line 1 = this district (bold, --viz-1), with a 10%-opacity area fill underneath.
- * Line 2 = statewide average per district (dashed, --viz-8).
+ * Total Spending Over Time. District line (bold, viz-1) with 10% area fill;
+ * statewide average per district line (dashed, viz-8).
  */
 export default function SpendingLineChart({ totals }) {
   const colors = useChartColors();
+  const isMobile = useIsMobile(640);
+  const reducedMotion = prefersReducedMotion();
 
   if (!totals || !totals.length) {
     return (
@@ -44,16 +63,18 @@ export default function SpendingLineChart({ totals }) {
       : null,
   }));
 
+  const height = isMobile ? CHART_H_MOBILE : CHART_H_DEFAULT;
+
   return (
     <div style={{ width: "100%" }}>
-      <ResponsiveContainer width="100%" height={CHART_H}>
+      <ResponsiveContainer width="100%" height={height}>
         <ComposedChart
           data={data}
           margin={{ top: 8, right: 16, bottom: 12, left: 8 }}
         >
           <defs>
             <linearGradient id="districtFill" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor={colors.total} stopOpacity={0.18} />
+              <stop offset="0%" stopColor={colors.total} stopOpacity={0.22} />
               <stop offset="100%" stopColor={colors.total} stopOpacity={0.02} />
             </linearGradient>
           </defs>
@@ -62,14 +83,17 @@ export default function SpendingLineChart({ totals }) {
             dataKey="year"
             tick={{ fontSize: 12, fill: colors.text }}
             stroke={colors.border}
+            tickLine={false}
           />
           <YAxis
             tickFormatter={fmtShortUSD}
             tick={{ fontSize: 12, fill: colors.text }}
             stroke={colors.border}
-            width={70}
+            tickLine={false}
+            width={isMobile ? 52 : 70}
           />
           <Tooltip
+            cursor={{ stroke: colors.border, strokeWidth: 1, strokeDasharray: "4 4" }}
             formatter={(value, name) => [
               Number.isFinite(value) ? fmtUSD0(value) : "—",
               name,
@@ -84,7 +108,8 @@ export default function SpendingLineChart({ totals }) {
             name="This district"
             stroke="none"
             fill="url(#districtFill)"
-            isAnimationActive={false}
+            isAnimationActive={!reducedMotion}
+            animationDuration={reducedMotion ? 0 : 900}
           />
           <Line
             type="monotone"
@@ -92,9 +117,10 @@ export default function SpendingLineChart({ totals }) {
             name="This district"
             stroke={colors.total}
             strokeWidth={2.5}
-            dot={{ r: 4, strokeWidth: 1, stroke: colors.surface, fill: colors.total }}
+            dot={{ r: 4, strokeWidth: 1.5, stroke: colors.surface, fill: colors.total }}
             activeDot={{ r: 6 }}
-            isAnimationActive={false}
+            isAnimationActive={!reducedMotion}
+            animationDuration={reducedMotion ? 0 : 900}
           />
           <Line
             type="monotone"
@@ -103,8 +129,9 @@ export default function SpendingLineChart({ totals }) {
             stroke={colors.statewide}
             strokeWidth={2}
             strokeDasharray="6 4"
-            dot={{ r: 3, strokeWidth: 1, stroke: colors.surface, fill: colors.statewide }}
-            isAnimationActive={false}
+            dot={{ r: 3, strokeWidth: 1, stroke: colors.surface, fill: colors.statewide, shape: "square" }}
+            isAnimationActive={!reducedMotion}
+            animationDuration={reducedMotion ? 0 : 900}
           />
         </ComposedChart>
       </ResponsiveContainer>

--- a/src/components/StaffingBar.jsx
+++ b/src/components/StaffingBar.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { num } from "../lib/format";
+
+/**
+ * Horizontal stacked bar showing teacher vs admin staffing split,
+ * with student-ratio annotations underneath.
+ *
+ * Props:
+ *   teacherCount, adminCount, tRatio, aRatio — all may be NaN
+ */
+export default function StaffingBar({ teacherCount, adminCount, tRatio, aRatio }) {
+  const tc = Number.isFinite(teacherCount) ? teacherCount : 0;
+  const ac = Number.isFinite(adminCount) ? adminCount : 0;
+  const total = tc + ac;
+
+  if (total <= 0) {
+    return (
+      <p className="text-sm text-[var(--text-muted)]">Staffing data unavailable.</p>
+    );
+  }
+
+  const tPct = (tc / total) * 100;
+  const aPct = (ac / total) * 100;
+
+  const fmtRatio = (r) =>
+    Number.isFinite(r) && r > 0 ? `1:${(1 / r).toFixed(1)}` : "—";
+
+  return (
+    <div>
+      <div
+        className="h-6 w-full rounded-full overflow-hidden flex border border-gray-200"
+        role="img"
+        aria-label={`Staffing split: ${tPct.toFixed(1)}% teachers, ${aPct.toFixed(1)}% administrators`}
+      >
+        <div
+          style={{ width: `${tPct}%`, background: "var(--viz-1)" }}
+          title={`Teachers: ${num.format(tc)}`}
+        />
+        <div
+          style={{ width: `${aPct}%`, background: "var(--viz-2)" }}
+          title={`Admin: ${num.format(ac)}`}
+        />
+      </div>
+      <div className="mt-2 flex flex-col sm:flex-row sm:justify-between gap-1 text-xs text-gray-700">
+        <span>
+          <span
+            className="inline-block h-2 w-2 rounded-full mr-2 align-middle"
+            style={{ background: "var(--viz-1)" }}
+          />
+          Teachers: {num.format(tc)} ({tPct.toFixed(1)}%) · T:S ratio {fmtRatio(tRatio)}
+        </span>
+        <span>
+          <span
+            className="inline-block h-2 w-2 rounded-full mr-2 align-middle"
+            style={{ background: "var(--viz-2)" }}
+          />
+          Admin: {num.format(ac)} ({aPct.toFixed(1)}%) · A:S ratio {fmtRatio(aRatio)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/StaffingBar.jsx
+++ b/src/components/StaffingBar.jsx
@@ -28,34 +28,64 @@ export default function StaffingBar({ teacherCount, adminCount, tRatio, aRatio }
   return (
     <div>
       <div
-        className="h-6 w-full rounded-full overflow-hidden flex border border-gray-200"
+        className="h-6 w-full rounded-full overflow-hidden flex"
+        style={{
+          border: "1px solid var(--border)",
+          boxShadow: "inset 0 1px 0 rgba(255,255,255,0.4)",
+        }}
         role="img"
         aria-label={`Staffing split: ${tPct.toFixed(1)}% teachers, ${aPct.toFixed(1)}% administrators`}
       >
         <div
-          style={{ width: `${tPct}%`, background: "var(--viz-1)" }}
+          style={{
+            width: `${tPct}%`,
+            background: "var(--viz-1)",
+            transition: "width 600ms cubic-bezier(0.22, 1, 0.36, 1)",
+          }}
           title={`Teachers: ${num.format(tc)}`}
         />
         <div
-          style={{ width: `${aPct}%`, background: "var(--viz-2)" }}
+          style={{
+            width: `${aPct}%`,
+            background: "var(--viz-2)",
+            transition: "width 600ms cubic-bezier(0.22, 1, 0.36, 1)",
+          }}
           title={`Admin: ${num.format(ac)}`}
         />
       </div>
-      <div className="mt-2 flex flex-col sm:flex-row sm:justify-between gap-1 text-xs text-gray-700">
-        <span>
+      <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
+        <div className="flex items-baseline gap-2">
           <span
-            className="inline-block h-2 w-2 rounded-full mr-2 align-middle"
+            className="inline-block h-2 w-2 rounded-full shrink-0"
             style={{ background: "var(--viz-1)" }}
+            aria-hidden="true"
           />
-          Teachers: {num.format(tc)} ({tPct.toFixed(1)}%) · T:S ratio {fmtRatio(tRatio)}
-        </span>
-        <span>
+          <span className="text-[var(--text-muted)] font-medium uppercase tracking-wider">
+            Teachers
+          </span>
+          <span className="tabular-nums font-semibold text-[var(--text-0)]">
+            {num.format(tc)}
+          </span>
+          <span className="text-[var(--text-muted)] tabular-nums">
+            · {tPct.toFixed(1)}% · T:S {fmtRatio(tRatio)}
+          </span>
+        </div>
+        <div className="flex items-baseline gap-2 sm:justify-end">
           <span
-            className="inline-block h-2 w-2 rounded-full mr-2 align-middle"
+            className="inline-block h-2 w-2 rounded-full shrink-0"
             style={{ background: "var(--viz-2)" }}
+            aria-hidden="true"
           />
-          Admin: {num.format(ac)} ({aPct.toFixed(1)}%) · A:S ratio {fmtRatio(aRatio)}
-        </span>
+          <span className="text-[var(--text-muted)] font-medium uppercase tracking-wider">
+            Admin
+          </span>
+          <span className="tabular-nums font-semibold text-[var(--text-0)]">
+            {num.format(ac)}
+          </span>
+          <span className="text-[var(--text-muted)] tabular-nums">
+            · {aPct.toFixed(1)}% · A:S {fmtRatio(aRatio)}
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/src/components/TopCostCentersChart.jsx
+++ b/src/components/TopCostCentersChart.jsx
@@ -1,0 +1,171 @@
+import React from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import {
+  fmtShortUSD,
+  fmtUSD0,
+  fmtSignedPct,
+  getObjectLabel,
+  useChartColors,
+  tooltipStyle,
+} from "../lib/spendingHelpers";
+
+const CHART_H = 360;
+
+const SORT_OPTIONS = [
+  { id: "amount", label: "2024 Amount" },
+  { id: "growth", label: "Growth Rate" },
+  { id: "alpha",  label: "A–Z" },
+];
+
+function sortObjects(list, mode) {
+  const arr = [...list];
+  if (mode === "growth") {
+    arr.sort((a, b) => {
+      const av = Number.isFinite(a.growthRate) ? a.growthRate : -Infinity;
+      const bv = Number.isFinite(b.growthRate) ? b.growthRate : -Infinity;
+      return bv - av;
+    });
+  } else if (mode === "alpha") {
+    arr.sort((a, b) =>
+      getObjectLabel(a.objectDescription).localeCompare(
+        getObjectLabel(b.objectDescription)
+      )
+    );
+  } else {
+    arr.sort((a, b) => (b.total2024 || 0) - (a.total2024 || 0));
+  }
+  return arr;
+}
+
+/**
+ * Grouped bar chart: top 5 object codes, bars per year.
+ * Bars are colored via --viz-1..--viz-5 palette.
+ */
+export default function TopCostCentersChart({ topObjects, years }) {
+  const colors = useChartColors();
+  const [sortMode, setSortMode] = React.useState("amount");
+
+  const sorted = React.useMemo(
+    () => sortObjects(topObjects || [], sortMode),
+    [topObjects, sortMode]
+  );
+
+  if (!topObjects || !topObjects.length || !years || !years.length) {
+    return (
+      <p className="text-sm text-[var(--text-muted)]">
+        No object-code data available.
+      </p>
+    );
+  }
+
+  // Build data: one row per object, one key per year.
+  const data = sorted.map((obj) => {
+    const row = {
+      key: obj.objectCode,
+      label: getObjectLabel(obj.objectDescription) || `Code ${obj.objectCode}`,
+      growthRate: obj.growthRate,
+    };
+    for (const y of years) {
+      row[`y${y}`] = Number.isFinite(obj.byYear?.[y]) ? obj.byYear[y] : 0;
+    }
+    return row;
+  });
+
+  // Palette: --viz-1 through --viz-5 (one per YEAR, so all bars for the same year
+  // share a color; top-5 ranking is shown on the X-axis label).
+  const yearColors = years.map((_, i) => colors.palette[i % colors.palette.length]);
+
+  return (
+    <div>
+      {/* Sort pills */}
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        <span className="text-xs text-[var(--text-muted)] mr-1">Sort:</span>
+        {SORT_OPTIONS.map((opt) => {
+          const active = sortMode === opt.id;
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => setSortMode(opt.id)}
+              className={`text-xs px-3 py-1 rounded-full border transition ${
+                active
+                  ? "bg-[var(--brand-500)] text-white border-[var(--brand-500)]"
+                  : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+              }`}
+              aria-pressed={active}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <ResponsiveContainer width="100%" height={CHART_H}>
+        <BarChart
+          data={data}
+          margin={{ top: 8, right: 16, bottom: 16, left: 8 }}
+        >
+          <CartesianGrid stroke={colors.grid} strokeDasharray="3 3" />
+          <XAxis
+            dataKey="label"
+            tick={{ fontSize: 11, fill: colors.text }}
+            stroke={colors.border}
+            interval={0}
+            angle={-16}
+            textAnchor="end"
+            height={60}
+          />
+          <YAxis
+            tickFormatter={fmtShortUSD}
+            tick={{ fontSize: 12, fill: colors.text }}
+            stroke={colors.border}
+            width={70}
+          />
+          <Tooltip
+            formatter={(value, name) => [
+              Number.isFinite(value) ? fmtUSD0(value) : "—",
+              String(name).replace(/^y/, ""),
+            ]}
+            labelFormatter={(label, payload) => {
+              const growth = payload?.[0]?.payload?.growthRate;
+              const growthText = Number.isFinite(growth)
+                ? ` — ${fmtSignedPct(growth)} since ${years[0]}`
+                : "";
+              return `${label}${growthText}`;
+            }}
+            contentStyle={tooltipStyle(colors)}
+          />
+          <Legend
+            verticalAlign="top"
+            align="left"
+            wrapperStyle={{ fontSize: 12 }}
+            formatter={(v) => String(v).replace(/^y/, "")}
+          />
+          {years.map((y, i) => (
+            <Bar
+              key={y}
+              dataKey={`y${y}`}
+              name={`y${y}`}
+              fill={yearColors[i]}
+              isAnimationActive={false}
+            >
+              {data.map((_, idx) => (
+                <Cell key={`${y}-${idx}`} fill={yearColors[i]} />
+              ))}
+            </Bar>
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/TopCostCentersChart.jsx
+++ b/src/components/TopCostCentersChart.jsx
@@ -19,7 +19,8 @@ import {
   tooltipStyle,
 } from "../lib/spendingHelpers";
 
-const CHART_H = 360;
+const CHART_H_DEFAULT = 360;
+const CHART_H_MOBILE = 280;
 
 const SORT_OPTIONS = [
   { id: "amount", label: "2024 Amount" },
@@ -47,12 +48,32 @@ function sortObjects(list, mode) {
   return arr;
 }
 
+function useIsMobile(breakpoint = 640) {
+  const [is, setIs] = React.useState(false);
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const sync = () => setIs(mql.matches);
+    sync();
+    mql.addEventListener?.("change", sync);
+    return () => mql.removeEventListener?.("change", sync);
+  }, [breakpoint]);
+  return is;
+}
+
+function prefersReducedMotion() {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
 /**
- * Grouped bar chart: top 5 object codes, bars per year.
- * Bars are colored via --viz-1..--viz-5 palette.
+ * Grouped bar chart: top 5 object codes, bars per year. Bars per year are
+ * colored from the --viz-1..--viz-5 palette.
  */
 export default function TopCostCentersChart({ topObjects, years }) {
   const colors = useChartColors();
+  const isMobile = useIsMobile(640);
+  const reducedMotion = prefersReducedMotion();
   const [sortMode, setSortMode] = React.useState("amount");
 
   const sorted = React.useMemo(
@@ -81,27 +102,25 @@ export default function TopCostCentersChart({ topObjects, years }) {
     return row;
   });
 
-  // Palette: --viz-1 through --viz-5 (one per YEAR, so all bars for the same year
-  // share a color; top-5 ranking is shown on the X-axis label).
-  const yearColors = years.map((_, i) => colors.palette[i % colors.palette.length]);
+  const yearColors = years.map(
+    (_, i) => colors.palette[i % colors.palette.length]
+  );
 
   return (
     <div>
       {/* Sort pills */}
-      <div className="flex flex-wrap items-center gap-2 mb-2">
-        <span className="text-xs text-[var(--text-muted)] mr-1">Sort:</span>
+      <div className="sort-pills mb-3">
+        <span className="text-[0.7rem] font-semibold uppercase tracking-wider text-[var(--text-muted)] mr-1">
+          Sort
+        </span>
         {SORT_OPTIONS.map((opt) => {
           const active = sortMode === opt.id;
           return (
             <button
               key={opt.id}
               type="button"
+              className="sort-pill"
               onClick={() => setSortMode(opt.id)}
-              className={`text-xs px-3 py-1 rounded-full border transition ${
-                active
-                  ? "bg-[var(--brand-500)] text-white border-[var(--brand-500)]"
-                  : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-              }`}
               aria-pressed={active}
             >
               {opt.label}
@@ -110,28 +129,34 @@ export default function TopCostCentersChart({ topObjects, years }) {
         })}
       </div>
 
-      <ResponsiveContainer width="100%" height={CHART_H}>
+      <ResponsiveContainer
+        width="100%"
+        height={isMobile ? CHART_H_MOBILE : CHART_H_DEFAULT}
+      >
         <BarChart
           data={data}
-          margin={{ top: 8, right: 16, bottom: 16, left: 8 }}
+          margin={{ top: 8, right: 16, bottom: isMobile ? 48 : 24, left: 8 }}
         >
           <CartesianGrid stroke={colors.grid} strokeDasharray="3 3" />
           <XAxis
             dataKey="label"
-            tick={{ fontSize: 11, fill: colors.text }}
+            tick={{ fontSize: isMobile ? 10 : 11, fill: colors.text }}
             stroke={colors.border}
+            tickLine={false}
             interval={0}
-            angle={-16}
+            angle={isMobile ? -45 : -16}
             textAnchor="end"
-            height={60}
+            height={isMobile ? 70 : 60}
           />
           <YAxis
             tickFormatter={fmtShortUSD}
             tick={{ fontSize: 12, fill: colors.text }}
             stroke={colors.border}
-            width={70}
+            tickLine={false}
+            width={isMobile ? 52 : 70}
           />
           <Tooltip
+            cursor={{ fill: "rgba(12, 58, 107, 0.05)" }}
             formatter={(value, name) => [
               Number.isFinite(value) ? fmtUSD0(value) : "—",
               String(name).replace(/^y/, ""),
@@ -157,7 +182,9 @@ export default function TopCostCentersChart({ topObjects, years }) {
               dataKey={`y${y}`}
               name={`y${y}`}
               fill={yearColors[i]}
-              isAnimationActive={false}
+              isAnimationActive={!reducedMotion}
+              animationDuration={reducedMotion ? 0 : 700}
+              animationBegin={reducedMotion ? 0 : i * 80}
             >
               {data.map((_, idx) => (
                 <Cell key={`${y}-${idx}`} fill={yearColors[i]} />

--- a/src/components/YearDetailTable.jsx
+++ b/src/components/YearDetailTable.jsx
@@ -1,0 +1,186 @@
+import React from "react";
+import {
+  fmtUSD0,
+  fmtInt,
+  fmtSignedPct,
+  getObjectLabel,
+} from "../lib/spendingHelpers";
+
+/**
+ * Year-over-year detail table with accordion rows. Clicking a year reveals
+ * the object-code breakdown for that year (sorted by spending descending).
+ *
+ * Props:
+ *   totals   — the totals[] array from getDistrictSpendingTimeline()
+ *   byObject — the flat byObject[] array from getDistrictSpendingTimeline()
+ */
+export default function YearDetailTable({ totals, byObject }) {
+  const [expanded, setExpanded] = React.useState(new Set());
+
+  const objectsByYear = React.useMemo(() => {
+    const map = new Map();
+    for (const row of byObject || []) {
+      if (!map.has(row.year)) map.set(row.year, []);
+      map.get(row.year).push(row);
+    }
+    for (const list of map.values()) {
+      list.sort((a, b) => (b.spending || 0) - (a.spending || 0));
+    }
+    return map;
+  }, [byObject]);
+
+  if (!totals || !totals.length) {
+    return (
+      <p className="text-sm text-[var(--text-muted)]">
+        No detail data available.
+      </p>
+    );
+  }
+
+  const sorted = [...totals].sort((a, b) => b.year - a.year);
+  const firstYear = Math.min(...totals.map((t) => t.year));
+  const byYearTotal = new Map(totals.map((t) => [t.year, t.totalSpending]));
+  const firstTotal = byYearTotal.get(firstYear);
+
+  const toggle = (year) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(year)) next.delete(year);
+      else next.add(year);
+      return next;
+    });
+  };
+
+  return (
+    <div className="data-table">
+      <div className="data-table__scroller">
+        <table className="w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left" style={{ width: 36 }} aria-label="Expand" />
+              <th className="text-left">Year</th>
+              <th className="align-right">Total Spending</th>
+              <th className="align-right">Enrollment</th>
+              <th className="align-right">Per-Student</th>
+              <th className="align-right">Change %</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((row) => {
+              const isOpen = expanded.has(row.year);
+              const objects = objectsByYear.get(row.year) || [];
+              const pctVsStart =
+                Number.isFinite(row.totalSpending) &&
+                Number.isFinite(firstTotal) &&
+                firstTotal > 0 &&
+                row.year !== firstYear
+                  ? (row.totalSpending - firstTotal) / firstTotal
+                  : NaN;
+
+              return (
+                <React.Fragment key={row.year}>
+                  <tr
+                    onClick={() => toggle(row.year)}
+                    style={{ cursor: "pointer" }}
+                    aria-expanded={isOpen}
+                  >
+                    <td>
+                      <span
+                        aria-hidden="true"
+                        style={{
+                          display: "inline-block",
+                          transition: "transform 120ms ease",
+                          transform: isOpen ? "rotate(90deg)" : "rotate(0deg)",
+                        }}
+                      >
+                        ▸
+                      </span>
+                    </td>
+                    <td>{row.year}</td>
+                    <td className="align-right tabular-nums">
+                      {Number.isFinite(row.totalSpending)
+                        ? fmtUSD0(row.totalSpending)
+                        : "—"}
+                    </td>
+                    <td className="align-right tabular-nums">
+                      {Number.isFinite(row.enrollment)
+                        ? fmtInt(row.enrollment)
+                        : "—"}
+                    </td>
+                    <td className="align-right tabular-nums">
+                      {Number.isFinite(row.perStudent)
+                        ? fmtUSD0(row.perStudent)
+                        : "—"}
+                    </td>
+                    <td className="align-right tabular-nums">
+                      {row.year === firstYear
+                        ? "baseline"
+                        : Number.isFinite(pctVsStart)
+                          ? fmtSignedPct(pctVsStart)
+                          : "—"}
+                    </td>
+                  </tr>
+                  {isOpen && (
+                    <tr>
+                      <td colSpan={6} style={{ background: "var(--surface-1)" }}>
+                        {objects.length === 0 ? (
+                          <p className="text-xs text-[var(--text-muted)] px-3 py-2">
+                            No object-code detail for {row.year}.
+                          </p>
+                        ) : (
+                          <div style={{ padding: "0.5rem 1rem" }}>
+                            <p className="text-xs text-[var(--text-muted)] mb-2">
+                              Object-code breakdown, {row.year}:
+                            </p>
+                            <table className="w-full text-xs">
+                              <thead>
+                                <tr>
+                                  <th className="text-left">Code</th>
+                                  <th className="text-left">Description</th>
+                                  <th className="align-right">Spending</th>
+                                  <th className="align-right">Share</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {objects.map((o) => {
+                                  const share =
+                                    Number.isFinite(row.totalSpending) &&
+                                    row.totalSpending > 0
+                                      ? o.spending / row.totalSpending
+                                      : NaN;
+                                  return (
+                                    <tr key={`${row.year}-${o.objectCode}`}>
+                                      <td className="tabular-nums">
+                                        {o.objectCode}
+                                      </td>
+                                      <td>
+                                        {getObjectLabel(o.objectDescription) ||
+                                          "—"}
+                                      </td>
+                                      <td className="align-right tabular-nums">
+                                        {fmtUSD0(o.spending)}
+                                      </td>
+                                      <td className="align-right tabular-nums">
+                                        {Number.isFinite(share)
+                                          ? `${(share * 100).toFixed(1)}%`
+                                          : "—"}
+                                      </td>
+                                    </tr>
+                                  );
+                                })}
+                              </tbody>
+                            </table>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/campusFinance.js
+++ b/src/lib/campusFinance.js
@@ -1,0 +1,81 @@
+// src/lib/campusFinance.js
+// Pure derivation helpers for the Campus Finances section on CampusDetail.
+// No React imports — easy to unit test later.
+
+/** Parse a CSV string/number/empty into a finite number, or NaN. */
+export const safeNum = (v) => {
+  if (v === null || v === undefined || v === "") return NaN;
+  const n = Number(String(v).replace(/[$,\s]/g, ""));
+  return Number.isFinite(n) ? n : NaN;
+};
+
+/**
+ * Derive all campus-finance metrics from a campus row + parent district row.
+ *
+ * @param {{ row: object|null, fields: object, districtRow: object|null, districtFields: object|null }} inputs
+ * @returns {object} derived metrics; every field is either a finite number or NaN/null.
+ */
+export function deriveCampusFinance({ row, fields, districtRow, districtFields }) {
+  const cv = (k) => (fields?.[k] ? safeNum(row?.[fields[k]]) : NaN);
+  const dv = (k) => (districtFields?.[k] ? safeNum(districtRow?.[districtFields[k]]) : NaN);
+
+  const enrollment   = cv("ENROLLMENT");
+  const teacherCount = cv("TEACHER_COUNT");
+  const adminCount   = cv("ADMIN_COUNT");
+  const teacherSal   = cv("AVG_TEACH_SAL");
+  const adminSal     = cv("AVG_ADMIN_SAL");
+
+  const perPupilSpend     = dv("PER_PUPIL_SPENDING");
+  const districtTeachSal  = dv("TEACHER_SALARY");
+  const districtPrincSal  = dv("PRINCIPAL_SALARY");
+
+  const estSpending =
+    Number.isFinite(perPupilSpend) && Number.isFinite(enrollment)
+      ? perPupilSpend * enrollment
+      : NaN;
+
+  const teacherComp =
+    Number.isFinite(teacherSal) && Number.isFinite(teacherCount)
+      ? teacherSal * teacherCount
+      : NaN;
+
+  const adminComp =
+    Number.isFinite(adminSal) && Number.isFinite(adminCount)
+      ? adminSal * adminCount
+      : NaN;
+
+  const totalComp =
+    (Number.isFinite(teacherComp) ? teacherComp : 0) +
+    (Number.isFinite(adminComp) ? adminComp : 0);
+
+  const tRatio =
+    Number.isFinite(teacherCount) && Number.isFinite(enrollment) && enrollment > 0
+      ? teacherCount / enrollment
+      : NaN;
+
+  const aRatio =
+    Number.isFinite(adminCount) && Number.isFinite(enrollment) && enrollment > 0
+      ? adminCount / enrollment
+      : NaN;
+
+  // TODO(phase-later): district-wide teacher/admin student ratios require a
+  // TEA staffing FTE file not currently in the repo. Until then we omit the
+  // ratio-vs-district comparison row and show only the campus ratio.
+
+  return {
+    enrollment,
+    teacherCount,
+    adminCount,
+    teacherSal,
+    adminSal,
+    estSpending,
+    perPupilSpend,
+    teacherComp,
+    adminComp,
+    totalComp,
+    tRatio,
+    aRatio,
+    districtTeachSal,
+    districtPrincSal,
+  };
+}

--- a/src/lib/campuses.js
+++ b/src/lib/campuses.js
@@ -1,5 +1,6 @@
 // src/lib/campuses.js
 import Papa from "papaparse";
+import { loadDistrictsCSV } from "./data";
 
 /** Data locations (env-first) */
 const CAMPUSES_CSV =
@@ -16,11 +17,15 @@ String(s ?? "")
 .replace(/[-_\s]+/g, "")
 .replace(/[^a-z0-9]/g, "");
 
-const canonId = (v) =>
+export const canonId = (v) =>
 String(v ?? "")
 .replace(/['"]/g, "")
 .replace(/\D/g, "")        // digits only
 .replace(/^0+/, "");       // strip leading zeros
+
+/** Default fallback path for districts CSV (matches Home/DistrictDetail) */
+const DISTRICTS_CSV =
+import.meta.env.VITE_DISTRICTS_CSV || "/data/Current_Districts_2025.csv";
 
 function buildHeaderMap(row) {
 // de-duplicate headers Papa may rename: "Foo","Foo-1"
@@ -262,7 +267,25 @@ const want = canonId(campusId);
 const { rows, fields } = await loadCampusesCSV();
 const kId = fields.CAMPUS_ID;
 const row = kId ? rows.find((r) => canonId(r[kId]) === want) : null;
-return { row: row || null, fields };
+
+let districtRow = null;
+let districtFields = null;
+if (row && fields.DISTRICT_ID) {
+try {
+const d = await loadDistrictsCSV(DISTRICTS_CSV);
+districtFields = d.fields;
+const wantDist = canonId(row[fields.DISTRICT_ID]);
+if (d.fields?.ID) {
+districtRow =
+d.rows.find((r) => canonId(r[d.fields.ID]) === wantDist) || null;
+}
+} catch (e) {
+// Swallow: section renders without district comparison
+console.warn("[Campuses] district lookup failed:", e?.message || e);
+}
+}
+
+return { row: row || null, fields, districtRow, districtFields };
 }
 
 export async function getCampusFeatureById(campusId) {

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -30,6 +30,10 @@ const KEYS = {
     "Per-Pupil Debt",
     "PER_PUPIL_DEBT", "DEBT_PER_STUDENT", "DEBT PER STUDENT",
   ],
+  PER_PUPIL_SPENDING: [
+    "Per-Pupil Spending",
+    "PER_PUPIL_SPENDING", "PER PUPIL SPENDING", "SPENDING_PER_PUPIL",
+  ],
   TEACHER_SALARY: [
     "Average Teacher Salary",
     "AVG_TEACHER_SALARY", "AVERAGE_TEACHER_SALARY", "TEACHER_AVG_SALARY",
@@ -102,6 +106,7 @@ export async function loadDistrictsCSV(csvUrl) {
     ENROLLMENT: pickKey(sample, KEYS.ENROLLMENT),
     DISTRICT_DEBT: pickKey(sample, KEYS.DISTRICT_DEBT),
     PER_PUPIL_DEBT: pickKey(sample, KEYS.PER_PUPIL_DEBT),
+    PER_PUPIL_SPENDING: pickKey(sample, KEYS.PER_PUPIL_SPENDING),
     TEACHER_SALARY: pickKey(sample, KEYS.TEACHER_SALARY),
     PRINCIPAL_SALARY: pickKey(sample, KEYS.PRINCIPAL_SALARY),
     SUPERINTENDENT_SALARY: pickKey(sample, KEYS.SUPERINTENDENT_SALARY),

--- a/src/lib/districtSpendingTimeline.js
+++ b/src/lib/districtSpendingTimeline.js
@@ -1,0 +1,309 @@
+// src/lib/districtSpendingTimeline.js
+// Loads and aggregates spending/enrollment time-series data for a single
+// district. Caches CSVs in module-level state so repeated district navigations
+// are cheap (Spending_By_Object_Long.csv is ~14MB — we parse it once).
+
+import Papa from "papaparse";
+import {
+  toNum,
+  canonDistrictId,
+  classifyObjectCode,
+  MACRO_CATEGORIES,
+} from "./spendingHelpers";
+
+const TOTALS_CSV     = "/data/Spending_Longitudinal_Totals.csv";
+const BY_OBJECT_CSV  = "/data/Spending_By_Object_Long.csv";
+const ENROLLMENT_CSV = "/data/Enrollment_Longitudinal.csv";
+
+/* ------------------------------------------------------------------ */
+/* CSV fetch + parse helpers                                           */
+/* ------------------------------------------------------------------ */
+
+async function fetchCsv(url) {
+  const text = await fetch(url, { cache: "force-cache" }).then((r) => {
+    if (!r.ok) throw new Error(`Fetch ${url} failed: ${r.status}`);
+    return r.text();
+  });
+  const parsed = Papa.parse(text, {
+    header: true,
+    dynamicTyping: false,
+    skipEmptyLines: true,
+  });
+  // Strip BOM from header keys
+  return parsed.data.map((r) => {
+    const clean = {};
+    for (const k of Object.keys(r)) {
+      const nk = String(k).replace(/^\uFEFF/, "").trim();
+      clean[nk] = r[k];
+    }
+    return clean;
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* Module caches                                                       */
+/* ------------------------------------------------------------------ */
+
+let _totalsCache = null;
+let _byObjectCache = null;
+let _enrollmentCache = null;
+
+async function loadTotals() {
+  if (_totalsCache) return _totalsCache;
+  _totalsCache = await fetchCsv(TOTALS_CSV);
+  return _totalsCache;
+}
+
+async function loadByObject() {
+  if (_byObjectCache) return _byObjectCache;
+  _byObjectCache = await fetchCsv(BY_OBJECT_CSV);
+  return _byObjectCache;
+}
+
+async function loadEnrollment() {
+  if (_enrollmentCache) return _enrollmentCache;
+  _enrollmentCache = await fetchCsv(ENROLLMENT_CSV);
+  return _enrollmentCache;
+}
+
+/* ------------------------------------------------------------------ */
+/* Row filters                                                         */
+/* ------------------------------------------------------------------ */
+
+const STATEWIDE_KEY = "STATEWIDE";
+
+const isStatewideRow = (row) =>
+  String(row?.DISTRICT_N || "").trim().toUpperCase() === STATEWIDE_KEY;
+
+const matchesDistrict = (row, wantCanonical) => {
+  if (isStatewideRow(row)) return false;
+  const v = row?.DISTRICT_N;
+  if (v === null || v === undefined || v === "") return false;
+  return canonDistrictId(v) === wantCanonical;
+};
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Load the spending timeline for a single district.
+ *
+ * @returns {Promise<{
+ *   years: number[],
+ *   totals: Array<{year:number, totalSpending:number, enrollment:number, perStudent:number, statewidePerDistrict:number}>,
+ *   byObject: Array<{year:number, objectCode:string, objectDescription:string, spending:number}>,
+ *   topObjects: Array<{objectCode:string, objectDescription:string, byYear: Record<number, number>, total2024:number, growthRate:number}>,
+ *   kpis: { totalChange:{start,end,delta,pct}, perStudentChange:{start,end,delta,pct}, enrollmentChange:{start,end,delta,pct} },
+ *   macroSeries: Array<{year:number, teacher:number, support:number, benefits:number, contracted:number, capital:number, other:number, total:number}>,
+ *   statewideTotals: Array<{year:number, totalSpending:number, districtCount:number, perDistrictAvg:number}>,
+ * }>}
+ */
+export async function getDistrictSpendingTimeline(districtId) {
+  const want = canonDistrictId(districtId);
+
+  const [totalsRaw, byObjectRaw, enrollmentRaw] = await Promise.all([
+    loadTotals(),
+    loadByObject(),
+    loadEnrollment(),
+  ]);
+
+  /* ---- totals for this district --------------------------------- */
+  const districtTotalsByYear = new Map();
+  for (const r of totalsRaw) {
+    if (!matchesDistrict(r, want)) continue;
+    const y = parseInt(r.Year, 10);
+    const v = toNum(r.Total_Spending);
+    if (Number.isFinite(y) && Number.isFinite(v)) {
+      districtTotalsByYear.set(y, v);
+    }
+  }
+
+  /* ---- statewide totals (for dashed comparison line) ------------- */
+  const statewideTotalByYear = new Map();
+  const districtCountByYear = new Map();
+  for (const r of totalsRaw) {
+    const y = parseInt(r.Year, 10);
+    if (!Number.isFinite(y)) continue;
+    if (isStatewideRow(r)) {
+      statewideTotalByYear.set(y, toNum(r.Total_Spending));
+    } else {
+      districtCountByYear.set(y, (districtCountByYear.get(y) || 0) + 1);
+    }
+  }
+
+  /* ---- enrollment for this district ----------------------------- */
+  // Enrollment CSV has columns: District, LEA Name, 2024, 2023, 2022, 2018
+  const enrollmentByYear = new Map();
+  for (const r of enrollmentRaw) {
+    if (canonDistrictId(r.District) !== want) continue;
+    for (const key of Object.keys(r)) {
+      const y = parseInt(key, 10);
+      if (!Number.isFinite(y)) continue;
+      const v = toNum(r[key]);
+      if (Number.isFinite(v)) enrollmentByYear.set(y, v);
+    }
+    break; // one row per district
+  }
+
+  /* ---- merged years --------------------------------------------- */
+  const years = Array.from(
+    new Set([
+      ...districtTotalsByYear.keys(),
+      ...enrollmentByYear.keys(),
+      ...statewideTotalByYear.keys(),
+    ])
+  ).sort((a, b) => a - b);
+
+  const totals = years.map((year) => {
+    const totalSpending = districtTotalsByYear.get(year) ?? NaN;
+    const enrollment = enrollmentByYear.get(year) ?? NaN;
+    const perStudent =
+      Number.isFinite(totalSpending) &&
+      Number.isFinite(enrollment) &&
+      enrollment > 0
+        ? totalSpending / enrollment
+        : NaN;
+    const statewideTotal = statewideTotalByYear.get(year);
+    const districtCount = districtCountByYear.get(year);
+    const statewidePerDistrict =
+      Number.isFinite(statewideTotal) && districtCount
+        ? statewideTotal / districtCount
+        : NaN;
+    return { year, totalSpending, enrollment, perStudent, statewidePerDistrict };
+  });
+
+  const statewideTotals = years.map((year) => ({
+    year,
+    totalSpending: statewideTotalByYear.get(year) ?? NaN,
+    districtCount: districtCountByYear.get(year) ?? 0,
+    perDistrictAvg:
+      Number.isFinite(statewideTotalByYear.get(year)) &&
+      districtCountByYear.get(year)
+        ? statewideTotalByYear.get(year) / districtCountByYear.get(year)
+        : NaN,
+  }));
+
+  /* ---- by-object for this district ------------------------------ */
+  const byObject = [];
+  for (const r of byObjectRaw) {
+    if (!matchesDistrict(r, want)) continue;
+    const year = parseInt(r.Year, 10);
+    const spending = toNum(r.Object_Spending);
+    if (!Number.isFinite(year) || !Number.isFinite(spending)) continue;
+    byObject.push({
+      year,
+      objectCode: String(r.Object_Code || "").trim(),
+      objectDescription: String(r.Object_Description_Long || "").trim(),
+      spending,
+    });
+  }
+
+  /* ---- top 5 object codes by 2024 spending ---------------------- */
+  const latestYear =
+    years.length > 0 ? years[years.length - 1] : null;
+
+  const byCode = new Map();
+  for (const row of byObject) {
+    if (!byCode.has(row.objectCode)) {
+      byCode.set(row.objectCode, {
+        objectCode: row.objectCode,
+        objectDescription: row.objectDescription,
+        byYear: new Map(),
+      });
+    }
+    const entry = byCode.get(row.objectCode);
+    // Prefer a non-empty description if we've seen it.
+    if (row.objectDescription && !entry.objectDescription) {
+      entry.objectDescription = row.objectDescription;
+    }
+    entry.byYear.set(row.year, row.spending);
+  }
+
+  const topObjects = Array.from(byCode.values())
+    .map((entry) => {
+      const latest = latestYear ? toNum(entry.byYear.get(latestYear)) : NaN;
+      const startYear = years[0];
+      const startVal = startYear ? toNum(entry.byYear.get(startYear)) : NaN;
+      const growthRate =
+        Number.isFinite(latest) && Number.isFinite(startVal) && startVal > 0
+          ? (latest - startVal) / startVal
+          : NaN;
+      return {
+        objectCode: entry.objectCode,
+        objectDescription: entry.objectDescription,
+        byYear: Object.fromEntries(entry.byYear),
+        total2024: Number.isFinite(latest) ? latest : 0,
+        growthRate,
+      };
+    })
+    .sort((a, b) => b.total2024 - a.total2024)
+    .slice(0, 5);
+
+  /* ---- macro category series ------------------------------------ */
+  const macroAgg = new Map(); // year -> { teacher, support, ... total }
+  const blank = () =>
+    MACRO_CATEGORIES.reduce(
+      (acc, c) => ({ ...acc, [c.id]: 0 }),
+      { total: 0 }
+    );
+  for (const row of byObject) {
+    const bucket = classifyObjectCode(row.objectCode);
+    if (!macroAgg.has(row.year)) macroAgg.set(row.year, blank());
+    const slot = macroAgg.get(row.year);
+    slot[bucket] += row.spending;
+    slot.total += row.spending;
+  }
+  const macroSeries = Array.from(macroAgg.entries())
+    .map(([year, v]) => ({ year, ...v }))
+    .sort((a, b) => a.year - b.year);
+
+  /* ---- KPIs ----------------------------------------------------- */
+  const firstYear = years[0];
+  const lastYear = years[years.length - 1];
+  const kpi = (startVal, endVal) => {
+    if (!Number.isFinite(startVal) || !Number.isFinite(endVal)) {
+      return { start: startVal, end: endVal, delta: NaN, pct: NaN };
+    }
+    const delta = endVal - startVal;
+    const pct = startVal !== 0 ? delta / startVal : NaN;
+    return { start: startVal, end: endVal, delta, pct };
+  };
+
+  const totalChange = kpi(
+    districtTotalsByYear.get(firstYear),
+    districtTotalsByYear.get(lastYear)
+  );
+  const enrollmentChange = kpi(
+    enrollmentByYear.get(firstYear),
+    enrollmentByYear.get(lastYear)
+  );
+
+  const perStudentFirst =
+    Number.isFinite(districtTotalsByYear.get(firstYear)) &&
+    enrollmentByYear.get(firstYear) > 0
+      ? districtTotalsByYear.get(firstYear) / enrollmentByYear.get(firstYear)
+      : NaN;
+  const perStudentLast =
+    Number.isFinite(districtTotalsByYear.get(lastYear)) &&
+    enrollmentByYear.get(lastYear) > 0
+      ? districtTotalsByYear.get(lastYear) / enrollmentByYear.get(lastYear)
+      : NaN;
+  const perStudentChange = kpi(perStudentFirst, perStudentLast);
+
+  const kpis = {
+    totalChange: { ...totalChange, startYear: firstYear, endYear: lastYear },
+    enrollmentChange: { ...enrollmentChange, startYear: firstYear, endYear: lastYear },
+    perStudentChange: { ...perStudentChange, startYear: firstYear, endYear: lastYear },
+  };
+
+  return {
+    years,
+    totals,
+    byObject,
+    topObjects,
+    kpis,
+    macroSeries,
+    statewideTotals,
+  };
+}

--- a/src/lib/exportChart.js
+++ b/src/lib/exportChart.js
@@ -1,0 +1,76 @@
+// src/lib/exportChart.js
+// Serialize an in-DOM SVG element to a PNG dataURL and trigger a download.
+// Mirrors the exportAsPNG pattern in DistrictSpendingPie.jsx so that users
+// can save any chart from the Spending Over Time section.
+
+const PIXEL_RATIO = 2; // export at 2x for crisper screenshots
+
+/**
+ * Find the first relevant SVG inside a container and export it as a PNG file.
+ *
+ * @param {HTMLElement} container
+ * @param {string} filename  — filename without extension
+ * @param {string} [bgColor] — background color; defaults to --surface-0
+ * @returns {Promise<void>}  — resolves when the download has started
+ */
+export async function downloadContainerSvgAsPng(
+  container,
+  filename,
+  bgColor
+) {
+  if (!container) throw new Error("No chart container supplied");
+  const svg = container.querySelector("svg");
+  if (!svg) throw new Error("No chart SVG found in container");
+
+  const rect = svg.getBoundingClientRect();
+  const w = Math.max(svg.viewBox?.baseVal?.width || rect.width, rect.width, 320);
+  const h = Math.max(svg.viewBox?.baseVal?.height || rect.height, rect.height, 200);
+
+  // Serialize a clone so we don't mutate the live SVG
+  const clone = svg.cloneNode(true);
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  clone.setAttribute("width", String(w));
+  clone.setAttribute("height", String(h));
+  if (!clone.getAttribute("viewBox")) {
+    clone.setAttribute("viewBox", `0 0 ${w} ${h}`);
+  }
+
+  const serialized = new XMLSerializer().serializeToString(clone);
+  const blob = new Blob([serialized], { type: "image/svg+xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+
+  try {
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+    await new Promise((resolve, reject) => {
+      image.onload = resolve;
+      image.onerror = () =>
+        reject(new Error("Failed to render chart as image"));
+      image.src = url;
+    });
+
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.round(w * PIXEL_RATIO);
+    canvas.height = Math.round(h * PIXEL_RATIO);
+    const ctx = canvas.getContext("2d");
+    const resolvedBg =
+      bgColor ||
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--surface-0")
+        .trim() ||
+      "#ffffff";
+    ctx.fillStyle = resolvedBg;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+    const pngUrl = canvas.toDataURL("image/png");
+    const a = document.createElement("a");
+    a.href = pngUrl;
+    a.download = `${filename || "chart"}.png`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/lib/spendingHelpers.js
+++ b/src/lib/spendingHelpers.js
@@ -1,0 +1,243 @@
+// src/lib/spendingHelpers.js
+// Shared utilities for the Spending Over Time section on DistrictDetail.
+// Helper patterns are lifted from LongitudinalSpending.jsx so that the
+// district-scoped section feels visually consistent with the statewide page.
+
+import React from "react";
+
+/* ------------------------------------------------------------------ */
+/* Parsing                                                             */
+/* ------------------------------------------------------------------ */
+
+/** Parse a currency/number string (e.g. "$99,988,017.00") into a finite number, else NaN. */
+export const toNum = (v) => {
+  if (v === null || v === undefined || v === "") return NaN;
+  if (typeof v === "number") return Number.isFinite(v) ? v : NaN;
+  const s = String(v).replace(/[^\d.\-]/g, "");
+  const n = parseFloat(s);
+  return Number.isFinite(n) ? n : NaN;
+};
+
+/** Canonicalize a district ID to digits-only, leading zeros stripped. */
+export const canonDistrictId = (v) =>
+  String(v ?? "").replace(/['"]/g, "").replace(/\D/g, "").replace(/^0+/, "");
+
+/* ------------------------------------------------------------------ */
+/* Formatters                                                          */
+/* ------------------------------------------------------------------ */
+
+export const fmtShortUSD = (n) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(Number.isFinite(n) ? n : 0);
+
+export const fmtUSD0 = (n) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(Number.isFinite(n) ? n : 0);
+
+export const fmtUSDShort = (n) => {
+  const v = Number(n);
+  if (!Number.isFinite(v)) return "$0";
+  const abs = Math.abs(v);
+  const sign = v < 0 ? "-" : "";
+  const trim = (x) => String(x.toFixed(1)).replace(/\.0$/, "");
+  if (abs >= 1_000_000_000) return `${sign}$${trim(abs / 1_000_000_000)}B`;
+  if (abs >= 1_000_000) return `${sign}$${trim(abs / 1_000_000)}M`;
+  if (abs >= 1_000) return `${sign}$${trim(abs / 1_000)}K`;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(v);
+};
+
+export const fmtInt = (n) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(
+    Number.isFinite(n) ? Math.round(n) : 0
+  );
+
+export const fmtSignedPct = (r) =>
+  Number.isFinite(r)
+    ? (r >= 0 ? "+" : "") +
+      new Intl.NumberFormat("en-US", {
+        style: "percent",
+        maximumFractionDigits: 1,
+      }).format(r)
+    : "—";
+
+export const fmtSignedUSDShort = (n) =>
+  Number.isFinite(n) ? (n >= 0 ? "+" : "−") + fmtUSDShort(Math.abs(n)) : "—";
+
+export const fmtSignedInt = (n) =>
+  Number.isFinite(n) ? (n >= 0 ? "+" : "−") + fmtInt(Math.abs(n)) : "—";
+
+/* ------------------------------------------------------------------ */
+/* Change / CAGR helpers (work on Map<year, value>)                    */
+/* ------------------------------------------------------------------ */
+
+export function calcChange(map) {
+  const years = Array.from(map.keys()).sort((a, b) => a - b);
+  if (years.length < 2) return null;
+  const startYear = years[0];
+  const endYear = years[years.length - 1];
+  const start = toNum(map.get(startYear));
+  const end = toNum(map.get(endYear));
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  const delta = end - start;
+  const pct = start !== 0 ? delta / start : null;
+  const trend = delta > 0 ? "up" : delta < 0 ? "down" : "flat";
+  return { startYear, endYear, start, end, delta, pct, trend };
+}
+
+/* ------------------------------------------------------------------ */
+/* Theme-aware chart colors (pattern from LongitudinalSpending.jsx)    */
+/* ------------------------------------------------------------------ */
+
+const FALLBACK_CHART_COLORS = {
+  total: "#0072B2",
+  palette: [
+    "#0072B2", "#E69F00", "#56B4E9", "#009E73",
+    "#F0E442", "#D55E00", "#CC79A7", "#999999",
+  ],
+  positive: "#10B981",
+  negative: "#DC2626",
+  grid: "rgba(15, 23, 42, 0.15)",
+};
+
+function readCssVar(name, fallback) {
+  if (typeof window === "undefined") return fallback;
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name);
+  return value ? value.trim() || fallback : fallback;
+}
+
+export function getChartColors() {
+  const palette = Array.from({ length: 8 }, (_, i) =>
+    readCssVar(`--viz-${i + 1}`, FALLBACK_CHART_COLORS.palette[i])
+  );
+  return {
+    total: palette[0] || FALLBACK_CHART_COLORS.total,
+    statewide: palette[7] || FALLBACK_CHART_COLORS.palette[7],
+    palette,
+    positive: readCssVar("--success-500", FALLBACK_CHART_COLORS.positive),
+    negative: readCssVar("--danger-500", FALLBACK_CHART_COLORS.negative),
+    grid: readCssVar("--grid-color", FALLBACK_CHART_COLORS.grid),
+    surface: readCssVar("--surface-0", "#ffffff"),
+    text: readCssVar("--text-0", "#0F172A"),
+    border: readCssVar("--border", "rgba(15,23,42,0.15)"),
+    radius: readCssVar("--radius-md", "12px"),
+  };
+}
+
+export function useChartColors() {
+  const [colors, setColors] = React.useState(getChartColors);
+  React.useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const root = document.documentElement;
+    const observer = new MutationObserver((mutations) => {
+      if (mutations.some((m) => m.attributeName === "data-theme")) {
+        setColors(getChartColors());
+      }
+    });
+    observer.observe(root, { attributes: true, attributeFilter: ["data-theme"] });
+    return () => observer.disconnect();
+  }, []);
+  return colors;
+}
+
+/** Standard recharts Tooltip contentStyle object derived from the current theme. */
+export function tooltipStyle(colors) {
+  return {
+    fontSize: 13,
+    backgroundColor: colors.surface,
+    color: colors.text,
+    borderRadius: colors.radius,
+    borderColor: colors.border,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Object-code labels                                                  */
+/* ------------------------------------------------------------------ */
+
+const TEACHER_PAY_LABEL = "Teacher Pay";
+
+export const OBJECT_LABEL_OVERRIDES = {
+  "BUILDING PURCHASE, CONSTRUCTION OR IMPROVEMENTS": "Building Purchases",
+  "CONSULTING SERVICES": "Consultants",
+  "PROFESSIONAL SERVICES": "Professional Services",
+  "MISCELLANEOUS CONTRACTED SERVICES": "Miscellaneous Contracts",
+  "TEACHER PAY & OTHER PROFESSIONALS": TEACHER_PAY_LABEL,
+  "LEGAL SERVICES": "Legal Services",
+  "LOBBYING": "Lobbying",
+};
+
+const SMALL_WORDS = new Set([
+  "and", "or", "the", "for", "of", "to", "a", "an", "in", "on", "by",
+]);
+const ACRONYM_WORDS = new Set([
+  "ADA", "ACT", "CTE", "ELL", "ESL", "FICA", "FTE", "GT", "IDEA", "IRS",
+  "PEIMS", "SAT", "SSA", "TEA", "TRS", "TSI",
+]);
+
+export function toTitleCase(value) {
+  if (!value) return "";
+  const parts = String(value).split(/([\s\/\-&,]+)/);
+  return parts
+    .map((part, index) => {
+      if (/^[\s\/\-&,]+$/.test(part)) return part;
+      const lower = part.toLowerCase();
+      if (SMALL_WORDS.has(lower) && index !== 0 && index !== parts.length - 1) {
+        return lower;
+      }
+      if (ACRONYM_WORDS.has(part.toUpperCase())) {
+        return part.toUpperCase();
+      }
+      if (/^[0-9]+$/.test(lower)) {
+        return part;
+      }
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join("")
+    .replace(/\bId\b/g, "ID");
+}
+
+export function getObjectLabel(raw) {
+  const base = String(raw || "").trim();
+  if (!base) return "";
+  const override = OBJECT_LABEL_OVERRIDES[base.toUpperCase()];
+  return override || toTitleCase(base);
+}
+
+/* ------------------------------------------------------------------ */
+/* Macro categories (5-6 buckets rolling up ~50 object codes)          */
+/* ------------------------------------------------------------------ */
+
+export const MACRO_CATEGORIES = [
+  { id: "teacher",    label: "Teacher Compensation", order: 0 },
+  { id: "support",    label: "Support Staff",        order: 1 },
+  { id: "benefits",   label: "Benefits",             order: 2 },
+  { id: "contracted", label: "Contracted Services",  order: 3 },
+  { id: "capital",    label: "Capital & Facilities", order: 4 },
+  { id: "other",      label: "Other",                order: 5 },
+];
+
+/**
+ * Classify a 4-digit PEIMS object code into one of the macro buckets.
+ * Codes are compared numerically to support both "6112" and 6112.
+ */
+export function classifyObjectCode(code) {
+  const n = parseInt(String(code ?? "").replace(/\D/g, ""), 10);
+  if (!Number.isFinite(n)) return "other";
+  if (n === 6112 || n === 6119) return "teacher";
+  if (n === 6121 || n === 6122 || n === 6129) return "support";
+  if (n >= 6141 && n <= 6146) return "benefits";
+  if (n >= 6211 && n <= 6299) return "contracted";
+  if (n >= 6600) return "capital";
+  return "other";
+}

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -3,128 +3,126 @@ import React from "react";
 
 export default function About() {
   return (
-    <main className="mx-auto max-w-3xl px-4">
-      <article className="bg-white border border-slate-200 rounded-2xl p-6 md:p-8 space-y-6 text-slate-800">
-        <h1 className="text-2xl font-bold text-slate-900">
-          About Open Texas Schools
-        </h1>
+    <main className="mx-auto max-w-3xl">
+      <article className="section-card editorial-article space-y-5">
+        <header>
+          <span className="eyebrow eyebrow--brand">About</span>
+          <h1>About LoneStar Ledger</h1>
+          <p className="dek">
+            Making Texas K–12 finance and operations easy to understand —
+            districts, campuses, vendors, and line items in one place.
+          </p>
+        </header>
 
-        <p className="leading-relaxed">
-          We make Texas K 12 finance and operations easy to understand. Districts, campuses, vendors, and line items are brought together in one place so families, educators, reporters, and lawmakers can see where dollars go and what students receive.
+        <p>
+          We bring public data together so families, educators, reporters, and
+          lawmakers can see where dollars go and what students receive.
         </p>
 
-        <h2 className="text-xl font-semibold text-slate-900">
-          What you can do here
-        </h2>
-        <p className="leading-relaxed">
-          Search any district or campus, review spending and staffing, look at performance, and compare peers across time. Each profile shows high level indicators with links to deeper detail so you can verify what you see.
+        <h2>What you can do here</h2>
+        <p>
+          Search any district or campus, review spending and staffing, look at
+          performance, and compare peers across time. Each profile shows
+          high-level indicators with links to deeper detail so you can verify
+          what you see.
         </p>
 
-        <h2 className="text-xl font-semibold text-slate-900">
-          Where our data comes from
-        </h2>
-        <p className="leading-relaxed">
-          All information on this site comes from public sources published by the State of Texas.
-        </p>
+        <h2>Where our data comes from</h2>
+        <p>All information on this site comes from public sources published by the State of Texas.</p>
         <ul className="list-disc pl-6 space-y-3">
-          <li className="leading-relaxed">
+          <li>
             <strong>Spending:</strong> PEIMS Financial Actuals from the Texas Education Agency
             <br />
             <a
               href="https://tea.texas.gov/finance-and-grants/state-funding/state-funding-reports-and-data/peims-access-database-financial-data-downloads"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-brand-700 underline break-words"
+              className="break-words"
             >
-              https://tea.texas.gov/finance-and-grants/state-funding/state-funding-reports-and-data/peims-access-database-financial-data-downloads
+              tea.texas.gov/finance-and-grants/…/peims-access-database-financial-data-downloads
             </a>
           </li>
-          <li className="leading-relaxed">
+          <li>
             <strong>School and district performance:</strong> TXschools.gov Accountability reports
             <br />
             <a
               href="https://txschools.gov/?lng=en"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-brand-700 underline break-words"
+              className="break-words"
             >
-              https://txschools.gov/?lng=en
+              txschools.gov
             </a>
           </li>
-          <li className="leading-relaxed">
+          <li>
             <strong>District debt:</strong> Texas Bond Review Board Debt Search
             <br />
             <a
               href="https://debtsearch.brb.texas.gov/"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-brand-700 underline break-words"
+              className="break-words"
             >
-              https://debtsearch.brb.texas.gov/
+              debtsearch.brb.texas.gov
             </a>
           </li>
-          <li className="leading-relaxed">
-            <strong>Grade level performance:</strong> Texas Academic Performance Reports
+          <li>
+            <strong>Grade-level performance:</strong> Texas Academic Performance Reports
             <br />
             <a
               href="https://rptsvr1.tea.texas.gov/perfreport/tapr/2024/index.html"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-brand-700 underline break-words"
+              className="break-words"
             >
-              https://rptsvr1.tea.texas.gov/perfreport/tapr/2024/index.html
+              rptsvr1.tea.texas.gov/perfreport/tapr/2024
             </a>
           </li>
-          <li className="leading-relaxed">
+          <li>
             <strong>Staff and salary:</strong> PEIMS Standard Reports
             <br />
             <a
               href="https://tea.texas.gov/reports-and-data/student-data/standard-reports/peims-standard-reports"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-brand-700 underline break-words"
+              className="break-words"
             >
-              https://tea.texas.gov/reports-and-data/student-data/standard-reports/peims-standard-reports
+              tea.texas.gov/…/peims-standard-reports
             </a>
           </li>
         </ul>
 
-        <h2 className="text-xl font-semibold text-slate-900">
-          How we handle the data
-        </h2>
-        <ul className="list-disc pl-6 space-y-2 leading-relaxed">
+        <h2>How we handle the data</h2>
+        <ul className="list-disc pl-6 space-y-2">
           <li>We retrieve source files exactly as released by each agency and keep them in their original form for audit and replication.</li>
-          <li>Calculations such as per pupil figures use student counts from the same school year shown on a profile. When a different count is required, the page will note it.</li>
+          <li>Calculations such as per-pupil figures use student counts from the same school year shown on a profile. When a different count is required, the page will note it.</li>
           <li>Some values may be rounded. Small rounding differences can cause a minor variance between category totals and grand totals.</li>
-          <li>When agencies revise files, we aim to refresh the site soon after those revisions post. A Last updated date appears on profiles when available.</li>
+          <li>When agencies revise files, we aim to refresh the site soon after those revisions post. A "Last updated" date appears on profiles when available.</li>
         </ul>
 
-        <h2 className="text-xl font-semibold text-slate-900">
-          Coverage and caveats
-        </h2>
-        <ul className="list-disc pl-6 space-y-2 leading-relaxed">
+        <h2>Coverage and caveats</h2>
+        <ul className="list-disc pl-6 space-y-2">
           <li>The site reflects what the agencies publish. If a source suppresses small counts for privacy or applies business rules, those same limits will appear here.</li>
           <li>Historical trends can be affected by accounting changes or district boundary changes. We note these cases when they are material.</li>
-          <li>Open Texas Schools is an independent project. It is not affiliated with TEA, TXschools.gov, or the Bond Review Board. Any errors are ours.</li>
+          <li>LoneStar Ledger is an independent project. It is not affiliated with TEA, TXschools.gov, or the Bond Review Board. Any errors are ours.</li>
         </ul>
 
-        <h2 className="text-xl font-semibold text-slate-900">Privacy</h2>
-        <p className="leading-relaxed">
-          We do not publish student level information. All data are aggregated and come from public releases. Any analytics we use are for improving the site experience and do not sell or share personal information.
+        <h2>Privacy</h2>
+        <p>
+          We do not publish student-level information. All data are aggregated
+          and come from public releases. Any analytics we use are for improving
+          the site experience and do not sell or share personal information.
         </p>
 
-        <h2 className="text-xl font-semibold text-slate-900">
-          Feedback or corrections
-        </h2>
-        <p className="leading-relaxed">
-          If you spot an error, have a question, or want to request a feature, please email{" "}
-          <a
-            href="mailto:communications@texaspolicy.com"
-            className="text-brand-700 underline"
-          >
+        <h2>Feedback or corrections</h2>
+        <p>
+          If you spot an error, have a question, or want to request a feature,
+          please email{" "}
+          <a href="mailto:communications@texaspolicy.com">
             communications@texaspolicy.com
           </a>
-          . Include the district or campus name, the page link, and a short note about what you believe needs review.
+          . Include the district or campus name, the page link, and a short note
+          about what you believe needs review.
         </p>
       </article>
     </main>

--- a/src/pages/CampusDetail.jsx
+++ b/src/pages/CampusDetail.jsx
@@ -4,6 +4,7 @@ import { getCampusById, getCampusFeatureById } from "../lib/campuses";
 import StatPill from "../ui/StatPill";
 import LeafMap from "../ui/Map";
 import GradeScorePill from "../ui/GradeScorePill";
+import CampusFinanceSection from "../components/CampusFinanceSection";
 import { usd, num } from "../lib/format";
 
 const parsePct = (v) => {
@@ -42,6 +43,8 @@ export default function CampusDetail() {
 
   const [row, setRow] = React.useState(null);
   const [fields, setFields] = React.useState({});
+  const [districtRow, setDistrictRow] = React.useState(null);
+  const [districtFields, setDistrictFields] = React.useState(null);
   const [geom, setGeom] = React.useState(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState(null);
@@ -53,10 +56,13 @@ export default function CampusDetail() {
 
     (async () => {
       try {
-        const { row, fields } = await getCampusById(id);
+        const { row, fields, districtRow: dR, districtFields: dF } =
+          await getCampusById(id);
         if (alive) {
           setRow(row);
           setFields(fields);
+          setDistrictRow(dR ?? null);
+          setDistrictFields(dF ?? null);
         }
         try {
           const feat = await getCampusFeatureById(id);
@@ -173,6 +179,16 @@ export default function CampusDetail() {
           </div>
         </div>
       </header>
+
+      {row && (
+        <CampusFinanceSection
+          row={row}
+          fields={fields}
+          districtRow={districtRow}
+          districtFields={districtFields}
+          campusName={name}
+        />
+      )}
 
       <section className="bg-white border rounded-2xl p-6 space-y-3">
         <h2 className="text-xl font-bold text-gray-900">Campus Location</h2>

--- a/src/pages/DistrictDetail.jsx
+++ b/src/pages/DistrictDetail.jsx
@@ -9,6 +9,7 @@ import DataTable from "../ui/DataTable";
 import { loadDistrictsCSV } from "../lib/data";
 import { getCampusesForDistrict } from "../lib/campuses";
 import DistrictSpendingPie from "../components/DistrictSpendingPie";
+import DistrictSpendingTimeline from "../components/DistrictSpendingTimeline";
 
 const DISTRICTS_CSV = import.meta.env.VITE_DISTRICTS_CSV || "/data/Current_Districts_2025.csv";
 const DISTRICTS_GEOJSON =
@@ -468,6 +469,11 @@ export default function DistrictDetail() {
         districtId={id}
         districtName={displayName}
         className="mt-6"
+      />
+
+      <DistrictSpendingTimeline
+        districtId={id}
+        districtName={displayName}
       />
 
       <section className="bg-white border rounded-2xl p-6 space-y-3">

--- a/src/pages/DistrictDetail.jsx
+++ b/src/pages/DistrictDetail.jsx
@@ -10,6 +10,7 @@ import { loadDistrictsCSV } from "../lib/data";
 import { getCampusesForDistrict } from "../lib/campuses";
 import DistrictSpendingPie from "../components/DistrictSpendingPie";
 import DistrictSpendingTimeline from "../components/DistrictSpendingTimeline";
+import CopyLinkButton from "../ui/CopyLinkButton";
 
 const DISTRICTS_CSV = import.meta.env.VITE_DISTRICTS_CSV || "/data/Current_Districts_2025.csv";
 const DISTRICTS_GEOJSON =
@@ -425,6 +426,9 @@ export default function DistrictDetail() {
                 <GradeScorePill grade={districtGrade} score={districtScore} />
               </div>
             )}
+            <div className="mt-3">
+              <CopyLinkButton label="Copy link to this district" />
+            </div>
           </div>
 
           <div className="flex flex-wrap gap-2 min-w-0">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -191,6 +191,7 @@ export default function Home() {
     <div className="space-y-12">
       <section className="hero">
         <div className="hero-inner">
+          <span className="eyebrow eyebrow--brand">Texas K–12 Transparency</span>
           <h1>
             Follow the <em>money</em> in Texas schools
           </h1>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -74,7 +74,7 @@ export default function Home() {
       key: "name",
       label: "District",
       format: (v, row) => (
-        <Link to={`/district/${row.id}`} className="text-indigo-700 hover:underline">
+        <Link to={`/district/${row.id}`} className="text-[color:var(--editorial-600)] hover:underline font-semibold">
           {v}
         </Link>
       ),
@@ -108,7 +108,7 @@ export default function Home() {
       key: "name",
       label: "District",
       format: (v, row) => (
-        <Link to={`/district/${row.id}`} className="text-indigo-700 hover:underline">
+        <Link to={`/district/${row.id}`} className="text-[color:var(--editorial-600)] hover:underline font-semibold">
           {v}
         </Link>
       ),
@@ -133,7 +133,7 @@ export default function Home() {
       key: "district",
       label: "District",
       format: (v, row) => (
-        <Link to={`/district/${row.id}`} className="text-indigo-700 hover:underline">
+        <Link to={`/district/${row.id}`} className="text-[color:var(--editorial-600)] hover:underline font-semibold">
           {v}
         </Link>
       ),
@@ -191,7 +191,9 @@ export default function Home() {
     <div className="space-y-12">
       <section className="hero">
         <div className="hero-inner">
-          <h1>Follow the money in Texas schools</h1>
+          <h1>
+            Follow the <em>money</em> in Texas schools
+          </h1>
           <p className="lead">Search any district or campus and see spending beside student results.</p>
           <form className="hero-actions" role="search" onSubmit={onHeroSearch}>
             <div className="autocomplete">

--- a/src/pages/Solutions.jsx
+++ b/src/pages/Solutions.jsx
@@ -60,20 +60,40 @@ const sections = [
 
 export default function Solutions() {
   return (
-    <div className="bg-white border rounded-2xl p-6 space-y-6 max-w-3xl">
-      <h1 className="text-2xl font-bold">Solutions</h1>
-      <div className="space-y-8">
-        {sections.map(({ title, paragraphs }) => (
+    <main className="mx-auto max-w-3xl">
+      <article className="section-card editorial-article space-y-4">
+        <header>
+          <span className="eyebrow eyebrow--brand">Editorial · Policy</span>
+          <h1>Solutions</h1>
+          <p className="dek">
+            Eight specific reforms that would make Texas K–12 finance more
+            transparent, accountable, and focused on students.
+          </p>
+        </header>
+
+        {sections.map(({ title, paragraphs }, i) => (
           <section key={title} className="space-y-2">
-            <h2 className="text-xl font-semibold">{title}</h2>
+            <h2>
+              <span
+                aria-hidden="true"
+                style={{
+                  fontFamily: "var(--font-display)",
+                  fontStyle: "italic",
+                  color: "var(--mesquite-600)",
+                  marginRight: "0.5rem",
+                  fontWeight: 500,
+                }}
+              >
+                {String(i + 1).padStart(2, "0")}.
+              </span>
+              {title}
+            </h2>
             {paragraphs.map((text, index) => (
-              <p key={index} className="text-gray-700">
-                {text}
-              </p>
+              <p key={index}>{text}</p>
             ))}
           </section>
         ))}
-      </div>
-    </div>
+      </article>
+    </main>
   );
 }

--- a/src/shell/Layout.jsx
+++ b/src/shell/Layout.jsx
@@ -36,7 +36,7 @@ function TopBar() {
     <header className="site-header">
       <div className="site-header__inner">
         <Link to="/" className="site-brand">
-          LoneStar Ledger
+          LoneStar <span className="site-brand__accent">Ledger</span>
         </Link>
         <button
           type="button"

--- a/src/shell/Layout.jsx
+++ b/src/shell/Layout.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 import useSearchSuggestions from "../hooks/useSearchSuggestions";
+import MobileTabBar from "./MobileTabBar";
 
 const NAV_LINKS = [
   { to: "/districts", label: "Districts" },
@@ -13,12 +14,13 @@ const NAV_LINKS = [
 
 export default function Layout({ children }) {
   return (
-    <div className="app-shell">
+    <div className="app-shell app-shell--with-tabbar">
       <TopBar />
       <main className="app-shell__content">
         <div className="app-shell__inner">{children}</div>
       </main>
       <Footer />
+      <MobileTabBar />
     </div>
   );
 }

--- a/src/shell/MobileTabBar.jsx
+++ b/src/shell/MobileTabBar.jsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+
+/* ------------------------------------------------------------------
+   Icons (inline SVGs, 22×22, stroke-only for theme-adaptive color).
+   Simple line-art feels native on mobile and works in both themes.
+   ------------------------------------------------------------------ */
+
+const Icon = ({ children, ...props }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="22"
+    height="22"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    {children}
+  </svg>
+);
+
+const HomeIcon = () => (
+  <Icon>
+    <path d="M3 12 12 3l9 9" />
+    <path d="M5 10v10a1 1 0 0 0 1 1h4v-6h4v6h4a1 1 0 0 0 1-1V10" />
+  </Icon>
+);
+
+const DistrictsIcon = () => (
+  <Icon>
+    <path d="M3 21V10l6-4 6 4v11" />
+    <path d="M15 21V14l6-2v9" />
+    <path d="M9 21v-6h2" />
+    <path d="M3 21h18" />
+  </Icon>
+);
+
+const CampusesIcon = () => (
+  <Icon>
+    <path d="M3 10 12 4l9 6" />
+    <path d="M6 10v10h12V10" />
+    <path d="M9 14h6" />
+    <path d="M9 18h6" />
+  </Icon>
+);
+
+const TrendsIcon = () => (
+  <Icon>
+    <path d="M4 19h16" />
+    <path d="M4 15l4-5 4 3 4-7 4 5" />
+    <circle cx="8" cy="10" r="1" />
+    <circle cx="12" cy="13" r="1" />
+    <circle cx="16" cy="6" r="1" />
+    <circle cx="20" cy="11" r="1" />
+  </Icon>
+);
+
+const AboutIcon = () => (
+  <Icon>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 16v-5" />
+    <path d="M12 8h.01" />
+  </Icon>
+);
+
+const TABS = [
+  { to: "/",          label: "Home",      Icon: HomeIcon,      end: true },
+  { to: "/districts", label: "Districts", Icon: DistrictsIcon },
+  { to: "/campuses",  label: "Campuses",  Icon: CampusesIcon },
+  { to: "/spending",  label: "Trends",    Icon: TrendsIcon },
+  { to: "/about",     label: "About",     Icon: AboutIcon },
+];
+
+/**
+ * Fixed-bottom primary navigation for mobile (<md). Replaces the hamburger
+ * drawer. Matches the native-feel pattern the user pointed to (ThisHome).
+ */
+export default function MobileTabBar() {
+  return (
+    <nav
+      className="mobile-tabbar"
+      aria-label="Primary"
+      role="navigation"
+    >
+      <ul className="mobile-tabbar__list">
+        {TABS.map(({ to, label, Icon: TabIcon, end }) => (
+          <li key={to} className="mobile-tabbar__item">
+            <NavLink
+              to={to}
+              end={end}
+              className={({ isActive }) =>
+                `mobile-tabbar__link${isActive ? " is-active" : ""}`
+              }
+              aria-label={label}
+            >
+              <span className="mobile-tabbar__icon" aria-hidden="true">
+                <TabIcon />
+              </span>
+              <span className="mobile-tabbar__label">{label}</span>
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1081,3 +1081,138 @@ a:hover { text-decoration: underline; }
   color: var(--ink-900);
   line-height: 1.4;
 }
+
+/* ------------------------------------------------------------------
+   Mobile tab bar — fixed bottom nav (<md), primary routes with icons.
+   Replaces the hamburger drawer as primary navigation on mobile.
+   ------------------------------------------------------------------ */
+
+.mobile-tabbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  background: var(--surface-0);
+  border-top: 1px solid var(--border);
+  box-shadow: 0 -4px 16px rgba(10, 31, 58, 0.08);
+  padding-bottom: env(safe-area-inset-bottom, 0); /* iOS home indicator */
+  display: none; /* desktop hides it */
+}
+.mobile-tabbar__list {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.mobile-tabbar__item { margin: 0; }
+.mobile-tabbar__link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  padding: 0.55rem 0.25rem 0.65rem;
+  text-decoration: none;
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  position: relative;
+  transition: color 150ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+.mobile-tabbar__link:hover {
+  color: var(--ink-900);
+  text-decoration: none;
+}
+.mobile-tabbar__link.is-active {
+  color: var(--mesquite-600);
+}
+.mobile-tabbar__link.is-active::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 28px;
+  height: 2.5px;
+  border-radius: 0 0 2px 2px;
+  background: var(--mesquite-600);
+}
+.mobile-tabbar__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+.mobile-tabbar__label {
+  line-height: 1;
+}
+
+/* When the tabbar is mounted, reserve bottom space on the main content
+   so nothing sits under the fixed bar on mobile. */
+@media (max-width: 767px) {
+  .mobile-tabbar { display: block; }
+  .app-shell--with-tabbar .app-shell__content {
+    padding-bottom: calc(72px + env(safe-area-inset-bottom, 0) + 1rem);
+  }
+  /* Hide the old hamburger + mobile drawer — tabbar is primary nav now */
+  .menu-toggle { display: none !important; }
+  .site-mobile-nav { display: none !important; }
+  /* Hide the footer — its visual space is filled by the tab bar */
+  .site-footer { display: none; }
+  /* Tighten the top bar so the hero takes the eye */
+  .site-header__inner {
+    padding: 0.5rem 0.875rem;
+    gap: 0.5rem;
+  }
+  .site-brand { font-size: 1.15rem; }
+  .site-controls { gap: 0.5rem; }
+  .site-search { flex: 1 1 auto; min-width: 0; }
+  .site-search .input { min-width: 0; width: 100%; }
+  .btn-subtle { padding: 0.45rem 0.6rem; font-size: 0.85rem; }
+}
+
+/* ------------------------------------------------------------------
+   Mobile hero refinements — tighter spacing, bolder CTA, eyebrow above H1
+   ------------------------------------------------------------------ */
+
+.hero .eyebrow {
+  margin-bottom: 0.5rem;
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 1.75rem 1rem 1.25rem;
+  }
+  .hero h1 {
+    font-size: clamp(1.85rem, 8vw, 2.5rem);
+    line-height: 1.05;
+  }
+  .lead {
+    font-size: 1rem;
+    color: var(--text-1);
+  }
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.625rem;
+  }
+  .hero-actions .autocomplete,
+  .hero-actions .input {
+    min-width: 0;
+    width: 100%;
+  }
+  .hero-actions .btn {
+    width: 100%;
+    justify-content: center;
+    padding: 0.85rem 1rem;
+    font-size: 1rem;
+  }
+  .hero-actions .btn-text {
+    padding: 0.625rem 0.5rem;
+    font-size: 0.9rem;
+  }
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -517,8 +517,14 @@ a:hover { text-decoration: underline; }
 .data-table tbody tr:nth-child(even) {
   background-color: var(--surface-1);
 }
+.data-table tbody tr {
+  transition: background-color 150ms ease;
+}
 .data-table tbody tr:hover {
   background-color: var(--brand-100);
+}
+:root[data-theme="dark"] .data-table tbody tr:hover {
+  background-color: color-mix(in srgb, var(--brand-500) 22%, transparent);
 }
 .data-table th button {
   display: inline-flex;
@@ -579,6 +585,243 @@ a:hover { text-decoration: underline; }
   .hero {
     padding: 2.5rem 1rem 2rem;
   }
+}
+
+/* ------------------------------------------------------------------
+   Phase 3 polish
+   ------------------------------------------------------------------ */
+
+/* Small caps "eyebrow" label above section headings */
+.eyebrow {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.eyebrow--brand {
+  color: var(--brand-500);
+}
+:root[data-theme="dark"] .eyebrow--brand {
+  color: #93C5FD;
+}
+
+/* Section heading with a colored accent bar on the left */
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-0);
+  line-height: 1.2;
+}
+.section-title::before {
+  content: "";
+  display: inline-block;
+  width: 3px;
+  height: 1.1em;
+  background: var(--brand-500);
+  border-radius: 2px;
+}
+.section-title--accent::before { background: var(--accent-500); }
+.section-title--success::before { background: var(--success-500); }
+
+/* Subsection heading: tighter, smaller, uppercase with faint color dot */
+.subsection-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  line-height: 1.2;
+  margin: 0;
+}
+.subsection-title__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--brand-500);
+  display: inline-block;
+}
+
+/* Eyebrow + numeric KPI (dense, Bloomberg-style) */
+.kpi--dense {
+  padding: 1rem 1.125rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  position: relative;
+  overflow: hidden;
+}
+.kpi--dense .label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.kpi--dense .value {
+  font-size: clamp(1.4rem, 2.4vw, 1.9rem);
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+}
+.kpi--dense .trend {
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.kpi--dense .sub {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.05em;
+}
+
+/* A left-edge accent rail (for "estimate" or "special" KPI tiles) */
+.kpi--accent::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--accent-500);
+}
+.kpi--brand::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--brand-500);
+}
+
+/* Skeleton shimmer */
+@keyframes ll-shimmer {
+  from { background-position: 200% 0; }
+  to   { background-position: -200% 0; }
+}
+.skeleton {
+  display: block;
+  border-radius: var(--radius-sm);
+  background-image: linear-gradient(
+    90deg,
+    var(--surface-2) 25%,
+    var(--surface-1) 50%,
+    var(--surface-2) 75%
+  );
+  background-size: 200% 100%;
+  animation: ll-shimmer 1.5s linear infinite;
+  color: transparent !important;
+  user-select: none;
+  pointer-events: none;
+}
+.skeleton--text { height: 0.85em; width: 100%; border-radius: 4px; }
+.skeleton--title { height: 1.2em; width: 40%; border-radius: 4px; }
+.skeleton--value { height: 1.8em; width: 65%; border-radius: 6px; }
+.skeleton--chart { height: 320px; width: 100%; border-radius: var(--radius-md); }
+.skeleton--block { height: 100px; width: 100%; border-radius: var(--radius-md); }
+
+/* Chart container surround (consistent spacing + subtle inner frame) */
+.chart-frame {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-0);
+  padding: 0.75rem;
+}
+
+/* Toast (ephemeral) */
+.toast {
+  position: fixed;
+  bottom: 1.25rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 60;
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  background: var(--text-0);
+  color: var(--surface-0);
+  font-size: 0.85rem;
+  font-weight: 600;
+  box-shadow: var(--shadow-2);
+  opacity: 0;
+  animation: ll-toast-in 2s ease both;
+}
+@keyframes ll-toast-in {
+  0% { opacity: 0; transform: translate(-50%, 6px); }
+  10%, 90% { opacity: 1; transform: translate(-50%, 0); }
+  100% { opacity: 0; transform: translate(-50%, -6px); }
+}
+
+/* Icon button (for Download / Copy link) */
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-0);
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: border-color 150ms ease, color 150ms ease, background 150ms ease;
+  cursor: pointer;
+}
+.icon-btn:hover {
+  color: var(--brand-500);
+  border-color: var(--brand-500);
+  background: var(--surface-1);
+}
+.icon-btn:focus-visible {
+  outline-offset: 2px;
+}
+
+/* Sort pills row used above charts */
+.sort-pills {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+.sort-pill {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-0);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: border-color 150ms ease, color 150ms ease, background 150ms ease;
+}
+.sort-pill:hover { color: var(--text-0); border-color: var(--text-muted); }
+.sort-pill[aria-pressed="true"] {
+  background: var(--brand-500);
+  border-color: var(--brand-500);
+  color: #ffffff;
+}
+
+/* Line chart — draw-on animation (first render only) */
+@keyframes ll-line-draw {
+  from { stroke-dashoffset: 1000; }
+  to   { stroke-dashoffset: 0; }
+}
+.chart-line-animate path.recharts-line-curve {
+  stroke-dasharray: 1000;
+  animation: ll-line-draw 900ms ease-out both;
+}
+.chart-line-animate path.recharts-area-area {
+  animation: ll-fade-in 900ms ease-out both;
+}
+@keyframes ll-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,23 +1,55 @@
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,400..700,0..100&display=swap');
+
 :root {
-  --brand-700: #0C3A6B;
-  --brand-500: #1F4E79;
-  --brand-100: #E6F0FF;
-  --accent-500: #D97706;
+  /* ===== Ink & Caliche palette =========================================
+     Editorial civic-tech identity: navy "ink" anchored on a warm caliche
+     paper neutral, with a mesquite (rust) warm accent, bluebonnet CTA,
+     and brick-red editorial highlight. The legacy --brand-*, --accent-*
+     names remain so existing rules keep working; the --ink-* / --mesquite-*
+     / --bluebonnet-* / --editorial-* names are the new vocabulary.
+     =================================================================== */
 
-  --surface-0: #FFFFFF;
-  --surface-1: #FBFDFF;
-  --surface-2: #F1F5F9;
+  /* Ink — the navy you write with (primary trust anchor) */
+  --ink-900: #0A1F3A;
+  --ink-700: #16365E;
+  --ink-100: #DCE4F2;
 
-  --text-0: #0F172A;
-  --text-1: #334155;
-  --text-muted: #475569;
+  /* Mesquite — warm Texas rust/terracotta (section accents, KPI rails,
+     outlier indicators on maps, eyebrow text) */
+  --mesquite-600: #9A3A1E;
+  --mesquite-100: #F5E4DA;
 
-  --success-500: #10B981;
-  --danger-500: #DC2626;
-  --warning-500: #F59E0B;
-  --focus-500: #2563EB;
+  /* Bluebonnet — action color, reads on both paper and graphite */
+  --bluebonnet-500: #2750D6;
 
-  /* Data viz palette, Okabe Ito */
+  /* Editorial — muted brick red for anchor links, pull quotes, "why this
+     matters" callouts. Distinct from --danger-500 semantically. */
+  --editorial-600: #B43A2E;
+
+  /* Legacy aliases — same values, old names, so existing rules don't break */
+  --brand-700: var(--ink-900);
+  --brand-500: var(--ink-700);
+  --brand-100: var(--ink-100);
+  --accent-500: var(--mesquite-600);
+
+  /* Surfaces — light mode is warm caliche paper, not pure white */
+  --surface-0: #FDFBF5;
+  --surface-1: #F7F2E8;
+  --surface-2: #EFE7D6;
+
+  /* Text */
+  --text-0: #0A1F3A;
+  --text-1: #3A4560;
+  --text-muted: #5B6577;
+  --text-inverse: #FDFBF5;
+
+  /* Semantic — retuned to sit next to mesquite without clashing */
+  --success-500: #15794D;
+  --danger-500:  #B43A2E;
+  --warning-500: #C78A1A;
+  --focus-500:   #2750D6;
+
+  /* Data viz palette — Okabe-Ito, unchanged (load-bearing in charts) */
   --viz-1: #0072B2;
   --viz-2: #E69F00;
   --viz-3: #56B4E9;
@@ -31,35 +63,56 @@
   --radius-md: 12px;
   --radius-lg: 16px;
 
-  --shadow-1: 0 1px 2px rgba(2, 6, 23, 0.06), 0 1px 1px rgba(2, 6, 23, 0.04);
-  --shadow-2: 0 8px 24px rgba(2, 6, 23, 0.10), 0 2px 6px rgba(2, 6, 23, 0.06);
+  --shadow-1: 0 1px 2px rgba(10, 31, 58, 0.06), 0 1px 1px rgba(10, 31, 58, 0.04);
+  --shadow-2: 0 8px 24px rgba(10, 31, 58, 0.10), 0 2px 6px rgba(10, 31, 58, 0.06);
 
-  --grid-color: rgba(12, 58, 107, 0.06);
-  --bg-tint-1: #F2F7FF;
-  --bg-tint-2: #EEF5FF;
+  --grid-color: rgba(10, 31, 58, 0.05);
+  --bg-tint-1: #F0E8D4;
+  --bg-tint-2: #E8DFC8;
 
-  --border: rgba(2, 6, 23, 0.08);
+  --border: rgba(10, 31, 58, 0.10);
   --pill-bg: var(--surface-2);
   --pill-border: var(--border);
-  --pill-text: #0F172A;
+  --pill-text: var(--ink-900);
+
+  /* Typography */
+  --font-display: "Fraunces", "Georgia", ui-serif, serif;
 }
 
 :root[data-theme="dark"] {
-  --surface-0: #0B1220;
-  --surface-1: #0F172A;
-  --surface-2: #111B2E;
+  /* Graphite — near-black with a whisper of blue, not "dark navy" */
+  --surface-0: #0A0F1A;
+  --surface-1: #121826;
+  --surface-2: #1A2333;
 
-  --text-0: #E5E7EB;
-  --text-1: #CBD5E1;
-  --text-muted: #94A3B8;
+  /* Ink inverts — on dark, ink IS the paper */
+  --ink-900: #E8ECF2;
+  --ink-700: #AFC0DA;
+  --ink-100: rgba(232, 236, 242, 0.12);
 
-  --border: rgba(203, 213, 225, 0.16);
-  --grid-color: rgba(147, 197, 253, 0.08);
-  --bg-tint-1: #0E1A2E;
-  --bg-tint-2: #0B1729;
-  --pill-bg: #FFFFFF;
-  --pill-border: rgba(255, 255, 255, 0.32);
-  --pill-text: #0F172A;
+  /* Warmer tones lifted for dark contrast */
+  --mesquite-600: #E27A4E;
+  --mesquite-100: #3A1E12;
+  --bluebonnet-500: #6A8BFF;
+  --editorial-600: #F07A6A;
+
+  --text-0: #ECEFF5;
+  --text-1: #C8D0DE;
+  --text-muted: #8A95A8;
+  --text-inverse: #0A0F1A;
+
+  --success-500: #4ECB95;
+  --danger-500:  #F07A6A;
+  --warning-500: #F0B659;
+  --focus-500:   #6A8BFF;
+
+  --border: rgba(226, 122, 78, 0.16); /* faint warm border vs pure cool */
+  --grid-color: rgba(226, 122, 78, 0.06); /* the single most identity-making line */
+  --bg-tint-1: #141A2A;
+  --bg-tint-2: #0F1524;
+  --pill-bg: var(--surface-1);
+  --pill-border: var(--border);
+  --pill-text: var(--ink-900);
 }
 
 html, body {
@@ -84,7 +137,7 @@ body {
 }
 
 a {
-  color: var(--brand-700);
+  color: var(--editorial-600);
   text-decoration-thickness: 2px;
   text-underline-offset: 3px;
 }
@@ -110,11 +163,14 @@ a:hover { text-decoration: underline; }
 .btn:active { transform: translateY(1px); }
 
 .btn-primary {
-  background: var(--brand-700);
-  color: white;
+  background: var(--bluebonnet-500);
+  color: var(--text-inverse);
   box-shadow: var(--shadow-1);
 }
-.btn-primary:hover { box-shadow: var(--shadow-2); background: var(--brand-500); }
+.btn-primary:hover {
+  box-shadow: var(--shadow-2);
+  background: color-mix(in srgb, var(--bluebonnet-500) 88%, black);
+}
 
 .btn-subtle {
   background: var(--surface-2);
@@ -127,10 +183,10 @@ a:hover { text-decoration: underline; }
 }
 .btn-text {
   background: transparent;
-  color: var(--brand-700);
+  color: var(--editorial-600);
 }
 .btn-text:hover {
-  background-color: rgba(12, 58, 107, 0.08);
+  background-color: color-mix(in srgb, var(--editorial-600) 10%, transparent);
 }
 
 .card-link {
@@ -194,9 +250,18 @@ a:hover { text-decoration: underline; }
   gap: 1rem;
 }
 .hero h1 {
-  font-size: clamp(2rem, 4vw, 3rem);
-  line-height: 1.1;
-  letter-spacing: -0.01em;
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-size: clamp(2.25rem, 4.2vw, 3.25rem);
+  font-weight: 500;
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+  color: var(--ink-900);
+}
+.hero h1 em {
+  font-style: italic;
+  color: var(--mesquite-600);
+  font-weight: 500;
 }
 .lead { color: var(--text-1); font-size: clamp(1rem, 1.6vw, 1.125rem); }
 .hero-actions {
@@ -303,10 +368,17 @@ a:hover { text-decoration: underline; }
   padding: 0.75rem 1rem;
 }
 .site-brand {
-  font-weight: 800;
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-weight: 600;
   letter-spacing: -0.01em;
-  font-size: 1.2rem;
-  color: var(--text-0);
+  font-size: 1.3rem;
+  color: var(--ink-900);
+}
+.site-brand .site-brand__accent {
+  color: var(--mesquite-600);
+  font-style: italic;
+  font-weight: 500;
 }
 .site-nav {
   display: none;
@@ -591,41 +663,51 @@ a:hover { text-decoration: underline; }
    Phase 3 polish
    ------------------------------------------------------------------ */
 
-/* Small caps "eyebrow" label above section headings */
+/* Editorial "eyebrow" label above section headings — Fraunces italic,
+   mesquite warm, lower-case tracking for a magazine feel */
 .eyebrow {
   display: inline-block;
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-size: 0.92rem;
+  font-weight: 500;
+  font-style: italic;
+  letter-spacing: 0.01em;
+  text-transform: none;
   color: var(--text-muted);
 }
 .eyebrow--brand {
-  color: var(--brand-500);
+  color: var(--mesquite-600);
+  font-variation-settings: "SOFT" 50;
 }
 :root[data-theme="dark"] .eyebrow--brand {
-  color: #93C5FD;
+  color: var(--mesquite-600);
 }
 
-/* Section heading with a colored accent bar on the left */
+/* Section heading with a colored accent bar on the left — now set in
+   Fraunces display for editorial gravitas */
 .section-title {
   display: flex;
   align-items: center;
   gap: 0.625rem;
-  font-size: 1.25rem;
-  font-weight: 700;
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  font-size: 1.55rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
   color: var(--text-0);
-  line-height: 1.2;
+  line-height: 1.15;
 }
 .section-title::before {
   content: "";
   display: inline-block;
   width: 3px;
   height: 1.1em;
-  background: var(--brand-500);
+  background: var(--mesquite-600);
   border-radius: 2px;
 }
-.section-title--accent::before { background: var(--accent-500); }
+.section-title--accent::before { background: var(--mesquite-600); }
+.section-title--brand::before  { background: var(--bluebonnet-500); }
 .section-title--success::before { background: var(--success-500); }
 
 /* Subsection heading: tighter, smaller, uppercase with faint color dot */
@@ -645,7 +727,7 @@ a:hover { text-decoration: underline; }
   width: 6px;
   height: 6px;
   border-radius: 999px;
-  background: var(--brand-500);
+  background: var(--mesquite-600);
   display: inline-block;
 }
 
@@ -689,14 +771,21 @@ a:hover { text-decoration: underline; }
   position: absolute;
   inset: 0 auto 0 0;
   width: 3px;
-  background: var(--accent-500);
+  background: var(--mesquite-600);
 }
 .kpi--brand::before {
   content: "";
   position: absolute;
   inset: 0 auto 0 0;
   width: 3px;
-  background: var(--brand-500);
+  background: var(--bluebonnet-500);
+}
+.kpi--editorial::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--editorial-600);
 }
 
 /* Skeleton shimmer */
@@ -802,9 +891,9 @@ a:hover { text-decoration: underline; }
 }
 .sort-pill:hover { color: var(--text-0); border-color: var(--text-muted); }
 .sort-pill[aria-pressed="true"] {
-  background: var(--brand-500);
-  border-color: var(--brand-500);
-  color: #ffffff;
+  background: var(--bluebonnet-500);
+  border-color: var(--bluebonnet-500);
+  color: var(--text-inverse);
 }
 
 /* Line chart — draw-on animation (first render only) */

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -916,3 +916,168 @@ a:hover { text-decoration: underline; }
 @media (prefers-reduced-motion: reduce) {
   * { animation: none !important; transition: none !important; }
 }
+
+/* ------------------------------------------------------------------
+   Dark-mode compatibility layer for pages that still use raw Tailwind
+   utility colors (bg-white, text-gray-*, border-gray-*, etc.). Rather
+   than refactoring every JSX file, we remap the most common hardcoded
+   utilities to palette tokens when data-theme="dark". Light mode keeps
+   Tailwind defaults — white cards on caliche paper read as newsprint.
+   ------------------------------------------------------------------ */
+
+:root[data-theme="dark"] .bg-white {
+  background-color: var(--surface-1) !important;
+}
+:root[data-theme="dark"] .bg-gray-50,
+:root[data-theme="dark"] .bg-slate-50,
+:root[data-theme="dark"] .bg-gray-100,
+:root[data-theme="dark"] .bg-slate-100 {
+  background-color: var(--surface-2) !important;
+}
+:root[data-theme="dark"] .hover\:bg-gray-50:hover,
+:root[data-theme="dark"] .hover\:bg-slate-50:hover,
+:root[data-theme="dark"] .hover\:bg-gray-100:hover {
+  background-color: var(--surface-2) !important;
+}
+
+:root[data-theme="dark"] .border,
+:root[data-theme="dark"] .border-gray-100,
+:root[data-theme="dark"] .border-gray-200,
+:root[data-theme="dark"] .border-gray-300,
+:root[data-theme="dark"] .border-slate-200 {
+  border-color: var(--border) !important;
+}
+
+:root[data-theme="dark"] .text-gray-900,
+:root[data-theme="dark"] .text-slate-900 {
+  color: var(--text-0) !important;
+}
+:root[data-theme="dark"] .text-gray-800,
+:root[data-theme="dark"] .text-slate-800,
+:root[data-theme="dark"] .text-gray-700,
+:root[data-theme="dark"] .text-slate-700 {
+  color: var(--text-1) !important;
+}
+:root[data-theme="dark"] .text-gray-600,
+:root[data-theme="dark"] .text-slate-600,
+:root[data-theme="dark"] .text-gray-500,
+:root[data-theme="dark"] .text-slate-500,
+:root[data-theme="dark"] .text-gray-400,
+:root[data-theme="dark"] .text-slate-400 {
+  color: var(--text-muted) !important;
+}
+
+/* Indigo/blue utility links → editorial brick (consistent with the new
+   anchor convention). Intentionally not mapping text-white (it stays white
+   — used inside dark tooltips where we want it to remain white). */
+:root[data-theme="dark"] .text-indigo-700,
+:root[data-theme="dark"] .text-indigo-800 {
+  color: var(--editorial-600) !important;
+}
+:root[data-theme="dark"] .bg-indigo-50 {
+  background-color: color-mix(in srgb, var(--bluebonnet-500) 22%, transparent) !important;
+}
+:root[data-theme="dark"] .border-indigo-400,
+:root[data-theme="dark"] .border-blue-400 {
+  border-color: var(--bluebonnet-500) !important;
+}
+:root[data-theme="dark"] .bg-blue-50 {
+  background-color: color-mix(in srgb, var(--bluebonnet-500) 22%, transparent) !important;
+}
+:root[data-theme="dark"] .bg-indigo-600,
+:root[data-theme="dark"] .bg-blue-700,
+:root[data-theme="dark"] .bg-blue-800 {
+  background-color: var(--bluebonnet-500) !important;
+}
+
+/* Dark tooltip / pill backgrounds (bg-gray-900 is used for chart tooltips
+   and should remain a dark pill in both themes) */
+:root[data-theme="dark"] .bg-gray-900 {
+  background-color: var(--ink-900) !important;
+  color: var(--text-inverse) !important;
+}
+
+/* Light-mode niceties: soften the pure-white cards slightly so they sit
+   better against caliche paper without losing their "fresh print" feel */
+.bg-white {
+  /* no-op in light mode; the override above handles dark */
+}
+
+/* ------------------------------------------------------------------
+   Editorial article pages (Solutions, About, WhyNoAmount, ...)
+   A content-width long-form reader with Fraunces display headings
+   and generous body spacing. Apply to the outer <article>.
+   ------------------------------------------------------------------ */
+
+.editorial-article {
+  font-size: 1.0625rem;
+  line-height: 1.7;
+  color: var(--text-0);
+}
+.editorial-article h1,
+.editorial-article h2,
+.editorial-article h3 {
+  font-family: var(--font-display);
+  font-optical-sizing: auto;
+  color: var(--ink-900);
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+}
+.editorial-article h1 {
+  font-size: clamp(1.85rem, 3.6vw, 2.5rem);
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+.editorial-article h1::after {
+  content: "";
+  display: block;
+  width: 48px;
+  height: 3px;
+  background: var(--mesquite-600);
+  border-radius: 2px;
+  margin-top: 0.75rem;
+}
+.editorial-article h2 {
+  font-size: 1.45rem;
+  font-weight: 500;
+  color: var(--ink-900);
+  margin-top: 1.5rem;
+}
+.editorial-article h3 {
+  font-size: 1.15rem;
+  font-weight: 500;
+  margin-top: 1.25rem;
+}
+.editorial-article p {
+  color: var(--text-1);
+  margin-bottom: 0.25rem;
+}
+.editorial-article p + p { margin-top: 0.25rem; }
+.editorial-article a {
+  color: var(--editorial-600);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.editorial-article strong { color: var(--text-0); }
+.editorial-article ul { color: var(--text-1); }
+.editorial-article ul li { margin-bottom: 0.375rem; }
+.editorial-article .dek {
+  /* subtitle / deck under the H1 */
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.125rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+  margin-top: 0.25rem;
+  margin-bottom: 0.75rem;
+}
+.editorial-article .pullquote {
+  border-left: 3px solid var(--editorial-600);
+  padding: 0.25rem 0 0.25rem 1rem;
+  margin: 1.25rem 0;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink-900);
+  line-height: 1.4;
+}

--- a/src/ui/AnimatedValue.jsx
+++ b/src/ui/AnimatedValue.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+
+/** Detect whether the user prefers reduced motion. */
+function prefersReducedMotion() {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * AnimatedValue — counts from 0 up to a target numeric value over `duration` ms
+ * using requestAnimationFrame and an ease-out curve. Renders the current value
+ * through a caller-provided `format` function so it composes with any of our
+ * formatters (USD, signed %, ints, etc).
+ *
+ * If the user prefers reduced motion, or if the target is not a finite number,
+ * the final value is rendered immediately.
+ *
+ * Props:
+ *   value     — target numeric value (may be NaN / null; in which case we render "—")
+ *   format    — function(n) => string; defaults to locale integer
+ *   duration  — ms, default 800
+ *   startFrom — default 0
+ *   className — optional
+ */
+export default function AnimatedValue({
+  value,
+  format = (n) => new Intl.NumberFormat("en-US").format(Math.round(n)),
+  duration = 800,
+  startFrom = 0,
+  className,
+}) {
+  const target = Number.isFinite(value) ? value : null;
+  const [display, setDisplay] = React.useState(() =>
+    target === null ? null : prefersReducedMotion() ? target : startFrom
+  );
+
+  React.useEffect(() => {
+    if (target === null) {
+      setDisplay(null);
+      return undefined;
+    }
+    if (prefersReducedMotion() || duration <= 0) {
+      setDisplay(target);
+      return undefined;
+    }
+
+    let rafId = null;
+    const start = performance.now();
+    const from = startFrom;
+    const to = target;
+    // ease-out cubic
+    const ease = (t) => 1 - Math.pow(1 - t, 3);
+
+    const tick = (now) => {
+      const elapsed = now - start;
+      const t = Math.min(1, elapsed / duration);
+      const eased = ease(t);
+      setDisplay(from + (to - from) * eased);
+      if (t < 1) {
+        rafId = requestAnimationFrame(tick);
+      } else {
+        setDisplay(to);
+      }
+    };
+    rafId = requestAnimationFrame(tick);
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [target, duration, startFrom]);
+
+  if (display === null) {
+    return <span className={className}>—</span>;
+  }
+  return <span className={className}>{format(display)}</span>;
+}

--- a/src/ui/CopyLinkButton.jsx
+++ b/src/ui/CopyLinkButton.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+
+/**
+ * Small button that copies the current page URL to the clipboard and flashes
+ * a toast. Used in the DistrictDetail header.
+ */
+export default function CopyLinkButton({
+  label = "Copy link",
+  successText = "Link copied",
+  className = "",
+}) {
+  const [toast, setToast] = React.useState(null);
+
+  const onClick = async () => {
+    try {
+      const url =
+        typeof window !== "undefined" ? window.location.href : "";
+      if (!url) return;
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+      } else {
+        const ta = document.createElement("textarea");
+        ta.value = url;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        document.execCommand("copy");
+        ta.remove();
+      }
+      setToast(successText);
+      setTimeout(() => setToast(null), 1900);
+    } catch (e) {
+      setToast("Copy failed");
+      setTimeout(() => setToast(null), 1900);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onClick}
+        className={`icon-btn ${className}`.trim()}
+        aria-label={label}
+        title={label}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.72" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.72" />
+        </svg>
+        {label}
+      </button>
+      {toast && (
+        <div className="toast" role="status" aria-live="polite">
+          {toast}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/ui/Skeleton.jsx
+++ b/src/ui/Skeleton.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+/**
+ * Shimmer skeleton placeholder. Use the `variant` prop or pass custom
+ * `className` / inline style for unusual shapes.
+ *
+ * Variants:
+ *   "text"  — 0.85em line
+ *   "title" — slightly taller, narrower
+ *   "value" — KPI-sized
+ *   "block" — 100px rectangle
+ *   "chart" — 320px rectangle (matches our line chart height)
+ *   "pill"  — short rounded-full placeholder
+ */
+export default function Skeleton({
+  variant = "text",
+  width,
+  height,
+  className = "",
+  style,
+  ...rest
+}) {
+  const modifier = `skeleton--${variant}`;
+  const classes = `skeleton ${modifier} ${className}`.trim();
+  const mergedStyle = { ...(style || {}) };
+  if (width !== undefined) mergedStyle.width = width;
+  if (height !== undefined) mergedStyle.height = height;
+  if (variant === "pill") {
+    mergedStyle.borderRadius = "999px";
+    if (!mergedStyle.height) mergedStyle.height = "1.5rem";
+    if (!mergedStyle.width) mergedStyle.width = "5rem";
+  }
+  return (
+    <span
+      className={classes}
+      style={mergedStyle}
+      aria-hidden="true"
+      {...rest}
+    />
+  );
+}
+
+/**
+ * Convenience composite: a "Loading KPI card" — 3 stacked skeleton shapes
+ * shaped like a label + big value + trend row, inside the same .card + .kpi
+ * container the real KPI row uses, so there is no layout shift.
+ */
+export function SkeletonKPI({ accent = "brand" }) {
+  return (
+    <div
+      className={`card stat-card kpi kpi--dense ${
+        accent === "accent" ? "kpi--accent" : "kpi--brand"
+      }`}
+    >
+      <Skeleton variant="title" width="55%" />
+      <Skeleton variant="value" width="80%" />
+      <Skeleton variant="text" width="35%" />
+    </div>
+  );
+}
+
+/** Skeleton block sized like a chart container. */
+export function SkeletonChart({ height = 320 }) {
+  return <Skeleton variant="chart" height={height} />;
+}
+
+/** Skeleton rows for a table (N rows of even height). */
+export function SkeletonTableRows({ rows = 4 }) {
+  return (
+    <div style={{ display: "grid", gap: "0.5rem", padding: "0.5rem 0" }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} variant="block" height={38} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a compelling campus-level financial profile section between the header
StatPills and the Campus Location map on CampusDetail. Derives metrics from
campus + parent-district CSV data since campus-level spending categories are
not yet available.

- Est. Campus Spending = district per-pupil × campus enrollment (estimate)
- Staffing Breakdown: horizontal stacked CSS bar with T:S / A:S ratios
- Compensation Split: 300x300 SVG donut mirroring DistrictSpendingPie pattern
- "How This Campus Compares": delta chips vs district averages
- Footnoted caveat: district CSV only tracks principal (not admin) salaries

New files:
- src/lib/campusFinance.js (pure derivation)
- src/components/CampusFinanceSection.jsx (container)
- src/components/CampusCompensationChart.jsx (two-slice donut)
- src/components/StaffingBar.jsx (CSS-only stacked bar)
- src/components/ComparisonRow.jsx (delta indicator)

Modified:
- src/lib/campuses.js: export canonId; extend getCampusById to additively
  return { districtRow, districtFields } via loadDistrictsCSV (fails soft)
- src/lib/data.js: add PER_PUPIL_SPENDING to KEYS and detected fields
- src/pages/CampusDetail.jsx: load district data; render CampusFinanceSection

All values gracefully handle NaN/missing data with "—" placeholders.